### PR TITLE
Minor compatibility changes

### DIFF
--- a/inc/VcfReader.hpp
+++ b/inc/VcfReader.hpp
@@ -1,11 +1,18 @@
 #pragma once
 
+#include "Filesystem.hpp"
+
+using ghc::filesystem::path;
+
 #include <climits>
+#include <numeric>
+#include <cmath>
 #include <utility>
 #include <string>
 #include <vector>
 #include <unordered_map>
 #include <fstream>
+#include <functional>
 #include <ostream>
 #include <iostream>
 
@@ -18,6 +25,7 @@ using std::function;
 using std::ifstream;
 using std::ostream;
 using std::cerr;
+using std::ceil;
 using std::runtime_error;
 
 namespace sv_merge {
@@ -260,16 +268,16 @@ public:
      * @param callback called on every VCF record that passes the constraints; see `VcfRecord` for details;
      * @param progress_n_lines prints a progress message to STDERR after this number of lines have been read (0=silent).
      */
-    VcfReader(const string& path, const function<void(VcfRecord& record)>& callback, uint32_t progress_n_lines, bool high_qual_only, float min_qual, bool pass_only, uint32_t min_sv_length, uint32_t n_samples_to_load, float min_allele_frequency, float min_nonmissing_frequency);
-    VcfReader(const string& path, const function<void(VcfRecord& record)>& callback);
+    VcfReader(const path& vcf_path, uint32_t progress_n_lines, bool high_qual_only, float min_qual, bool pass_only, uint32_t min_sv_length, uint32_t n_samples_to_load, float min_allele_frequency, float min_nonmissing_frequency);
+    VcfReader(const path& vcf_path);
 
-    void for_record_in_vcf();
+    void for_record_in_vcf(const function<void(VcfRecord& record)>& callback);
 
 private:
     /**
      * Internal state of VcfReader
      */
-    string path;
+    string vcf_path;
     function<void(VcfRecord& record)> callback;
 };
 

--- a/src/VcfReader.cpp
+++ b/src/VcfReader.cpp
@@ -57,9 +57,8 @@ const string VcfReader::BND_STR = "BND";
 const uint64_t VcfRecord::STREAMSIZE_MAX = numeric_limits<streamsize>::max();
 
 
-VcfReader::VcfReader(const string& path, const function<void(VcfRecord& record)>& callback, uint32_t progress_n_lines, bool high_qual_only, float min_qual, bool pass_only, uint32_t min_sv_length, uint32_t n_samples_to_load, float min_allele_frequency, float min_nonmissing_frequency) {
-    this->path=path;
-    this->callback=callback;
+VcfReader::VcfReader(const path& vcf_path, uint32_t progress_n_lines, bool high_qual_only, float min_qual, bool pass_only, uint32_t min_sv_length, uint32_t n_samples_to_load, float min_allele_frequency, float min_nonmissing_frequency) {
+    this->vcf_path=vcf_path;
     this->progress_n_lines=progress_n_lines;
     this->high_qual_only=high_qual_only;
     this->min_qual=min_qual;
@@ -72,9 +71,8 @@ VcfReader::VcfReader(const string& path, const function<void(VcfRecord& record)>
 }
 
 
-VcfReader::VcfReader(const string& path, const function<void(VcfRecord& record)>& callback) {
-    this->path=path;
-    this->callback=callback;
+VcfReader::VcfReader(const path& vcf_path) {
+    this->vcf_path=vcf_path;
     progress_n_lines=10000;
     high_qual_only=false;
     min_qual=0.0;
@@ -411,7 +409,7 @@ void VcfRecord::info2map(unordered_map<string,string>& map) {
 }
 
 
-void VcfReader::for_record_in_vcf() {
+void VcfReader::for_record_in_vcf(const function<void(VcfRecord& record)>& callback) {
     bool is_header;
     char c;
     uint8_t i;
@@ -420,8 +418,8 @@ void VcfReader::for_record_in_vcf() {
     VcfRecord record(high_qual_only,min_qual,pass_only,min_sv_length,n_samples_to_load,min_allele_frequency,min_nonmissing_frequency);
     ifstream file;
 
-    file.open(path,std::ifstream::in);
-    if (!file.is_open() || !file.good()) throw runtime_error("ERROR: could not read file: " + path);
+    file.open(vcf_path,std::ifstream::in);
+    if (!file.is_open() || !file.good()) throw runtime_error("ERROR: could not read file: " + vcf_path);
     n_lines=0;
     while (!file.eof()) {
         c=file.peek();

--- a/src/test/test_vcfreader.cpp
+++ b/src/test/test_vcfreader.cpp
@@ -32,9 +32,9 @@ void test(const string& test_id, const string& chromosome, const bool& high_qual
     cerr << "   n_samples_to_load: " << n_samples_to_load << '\n';
     cerr << "   min_allele_frequency: " << min_af << '\n';
     cerr << "   min_nonmissing_frequency: " << min_nmf << '\n';
-    VcfReader reader(input_vcf,test_callback,10000,high_qual_only,min_qual,pass_only,min_sv_length,n_samples_to_load,min_af,min_nmf);
+    VcfReader reader(input_vcf,10000,high_qual_only,min_qual,pass_only,min_sv_length,n_samples_to_load,min_af,min_nmf);
     outstream.open(test_vcf);
-    reader.for_record_in_vcf();
+    reader.for_record_in_vcf(test_callback);
     outstream.close();
     string command = "diff --brief "+test_vcf.string()+" "+truth_vcf.string();
     run_command(command);


### PR DESCRIPTION
Minor changes to import statements to compile on Ubuntu
Switched to using `path` object for file paths to be conformant with the rest of hapestry
Moved function "callback" to the `for_record_in_vcf()` definition for compatibility with lambdas