### PR TITLE
Fixed flank_length vs interior_flank_length issue

### DIFF
--- a/inc/VariantGraph.hpp
+++ b/inc/VariantGraph.hpp
@@ -92,7 +92,7 @@ public:
      * @param callers caller names (lowercase), used just for printing statistics; caller names must occur in the ID
      * field of a VCF record in order to be considered.
      */
-    void build(vector<VcfRecord>& records, int32_t flank_length, int32_t interior_flank_length, bool deallocate_ref_alt, const vector<string>& callers={});
+    void build(vector<VcfRecord>& records, int32_t flank_length, int32_t interior_flank_length = INT32_MAX, bool deallocate_ref_alt = false, const vector<string>& callers = {});
 
     /**
      * Serializes the bidirected graph, including paths, if any.

--- a/inc/VariantGraph.hpp
+++ b/inc/VariantGraph.hpp
@@ -50,9 +50,12 @@ public:
 
     /**
      * @param chromosomes map id -> sequence;
-     * @param tandem_track a sorted list of zero-based, non-overlapping intervals per chromosome, with format `[x..y)`.
+     * @param tandem_track map chromosome -> sorted list of zero-based, non-overlapping intervals, with format `[x..y)`.
+     * A chromosome might not appear in the map. A chromosome might appear in the map and its list of intervals might be
+     * empty. The tandem track is used for adding flanking regions with enough non-tandem sequence to the graph, which
+     * is useful for seeding graph alignments: see `build()` for more details.
      */
-    VariantGraph(const unordered_map<string,string>& chromosomes, const unordered_map<string,vector<interval_t>>& tandem_track);
+    VariantGraph(const unordered_map<string,string>& chromosomes, const unordered_map<string,vector<interval_t>>& tandem_track = {});
 
     /**
      * Given a list of VCF records from the same chromosome, the procedure builds a corresponding bidirected graph and
@@ -77,14 +80,19 @@ public:
      * except their ID, e.g. if they were created by different callers (although such records would have been merged by
      * `bcftools merge` and their IDs would have been concatenated).
      * @param flank_length ensures that an interval of this length, with no overlap to the tandem track, is present
-     * before the leftmost breakpoint (after the rightmost breakpoint) of every chromosome in the graph; if two
-     * consecutive breakpoints are farther away than `flank_length`, two disconnected nodes are created;
+     * before the leftmost breakpoint (after the rightmost breakpoint) of every chromosome in the graph;
+     * @param interior_flank_length consider two consecutive breakpoints A, B on the same chromosome; the procedure
+     * computes the shortest window to the right of A (resp. to the left of B) that contains an interval of this length
+     * with no overlap to the tandem track; if the windows of A and of B do not overlap, two disconnected nodes are
+     * created; otherwise, a single node [A..B) is created; this is useful to avoid creating long nodes when the
+     * breakpoints of a chromosome form clusters that are far away from one another; this parameter should be set to a
+     * small multiple of average read length;
      * @param deallocate_ref_alt TRUE: the procedure deallocates every REF and ALT field in `records`; this can be
      * useful for reducing space, since these fields might contain explicit DNA sequences;
      * @param callers caller names (lowercase), used just for printing statistics; caller names must occur in the ID
      * field of a VCF record in order to be considered.
      */
-    void build(vector<VcfRecord>& records, int32_t flank_length, bool deallocate_ref_alt, const vector<string>& callers={});
+    void build(vector<VcfRecord>& records, int32_t flank_length, int32_t interior_flank_length, bool deallocate_ref_alt, const vector<string>& callers={});
 
     /**
      * Serializes the bidirected graph, including paths, if any.

--- a/inc/VariantGraph.hpp
+++ b/inc/VariantGraph.hpp
@@ -94,6 +94,14 @@ public:
      */
     void build(vector<VcfRecord>& records, int32_t flank_length, int32_t interior_flank_length = INT32_MAX, bool deallocate_ref_alt = false, const vector<string>& callers = {});
 
+
+    /**
+     * Builds a trivial graph that contains one node for string `chromosome[p..q)` (zero-based) and two nodes for
+     * the flanking sequences.
+     */
+    void build(const string& chromosome, int32_t p, int32_t q, int32_t flank_length);
+
+
     /**
      * Serializes the bidirected graph, including paths, if any.
      */
@@ -406,7 +414,7 @@ private:
      * @param pos zero-based;
      * @param tandem_track a sorted list of non-overlapping intervals per chromosome, with format `[x..y)`;
      * @return the smallest `y` such that `[x..y]` has no intersection with `tandem_track`, `y-x+1=flank_length`, and
-     * `x>pos`; returns `INT32_MAX` if no such interval exists.
+     * `x>=pos`; returns `INT32_MAX` if no such interval exists.
      */
     int32_t get_flank_boundary_right(const string& chromosome_id, int32_t pos, int32_t flank_length);
 

--- a/inc/VariantGraph.hpp
+++ b/inc/VariantGraph.hpp
@@ -97,6 +97,9 @@ public:
     /**
      * Builds a trivial graph that contains one node for string `chromosome[p..q)` (zero-based) and one node for each
      * of its flanking sequences (if they exist).
+     *
+     * @param flank_length ensures that an interval of this length, with no overlap to the tandem track, is present
+     * before `p` and at or after `q`.
      */
     void build(const string& chromosome, int32_t p, int32_t q, int32_t flank_length);
 

--- a/inc/VariantGraph.hpp
+++ b/inc/VariantGraph.hpp
@@ -110,7 +110,8 @@ public:
     /**
      * Consider the set of VCF records that were used for building `graph`. Every such VCF record R corresponds to a
      * sequence of non-reference edges. The procedure writes to a file every R such that there is a (possibly circular)
-     * path P in `graph` that traverses the entire sequence of non-reference edges of R, or its reverse.
+     * path P in `graph` that traverses the entire sequence of non-reference edges of R, or its reverse. The procedure
+     * writes to another file every R for which this does not hold.
      *
      * Remark: in the current implementation, DELs that remove a prefix or suffix of a chromosome create no edge in the
      * graph, so they cannot be supported by a path and they are not printed in output. This could be solved by creating
@@ -121,12 +122,12 @@ public:
      *
      * Remark: for every pair of mated BND records, the procedure outputs just one of them.
      *
-     * @param print_all_records TRUE=disregard paths and print every VCF record in input (including those that were not
-     * used for building the graph);
+     * @param print_all_records TRUE=disregard paths and print every VCF record to `supported` (including those that
+     * were not used for building the graph), and no VCF record to `unsupported`;
      * @param callers caller names (lowercase), used just for printing statistics; caller names must occur in the ID
      * field of a VCF record to be counted.
      */
-    void print_supported_vcf_records(ofstream& outstream, bool print_all_records, const vector<string>& callers= {});
+    void print_supported_vcf_records(ofstream& supported, ofstream& unsupported, bool print_all_records, const vector<string>& callers = {});
 
     /**
      * Writes every path handle in `graph` as a distinct VCF record:
@@ -146,12 +147,34 @@ public:
     void paths_to_vcf_records(ofstream& outstream);
 
     /**
-     * If `mode=TRUE`, makes `out` the set of all IDs of nodes that have edges only on one side. Otherwise, prints
+     * If `mode=TRUE`, makes `out` the set of all IDs of nodes that have neighbors only on one side. Otherwise, prints
      * information about dangling nodes to STDERR.
      */
     void get_dangling_nodes(bool mode, unordered_set<nid_t>& out) const;
 
     size_t get_n_dangling_nodes() const;
+
+    /**
+     * @return TRUE iff the node has neighbors only on one side.
+     */
+    bool is_dangling_node(const handle_t& node_handle) const;
+
+    /**
+     * @return TRUE iff the node has neighbors only on one side.
+     */
+    bool is_dangling_node(const nid_t& node_id) const;
+
+    /**
+     * @return TRUE iff the node has neighbors only on one side, and belongs to the chromosome where all the POS
+     * fields of `vcf_records` are located.
+     */
+    bool is_flanking_node(const handle_t& node_handle) const;
+
+    /**
+     * @return TRUE iff the node has neighbors only on one side, and belongs to the chromosome where all the POS
+     * fields of `vcf_records` are located.
+     */
+    bool is_flanking_node(const nid_t& node_id) const;
 
     /**
      * @return the number of edges between two reference nodes that belong to different chromosomes. This might be
@@ -165,12 +188,12 @@ public:
      */
     size_t get_n_ins_edges() const;
 
-    bool is_reference_node(const nid_t& node_id);
+    bool is_reference_node(const nid_t& node_id) const;
 
     /**
      * @param node_handle in any orientation.
      */
-    bool is_reference_node(const handle_t& node_handle);
+    bool is_reference_node(const handle_t& node_handle) const;
 
     /**
      * @param edge in any orientation.

--- a/inc/VariantGraph.hpp
+++ b/inc/VariantGraph.hpp
@@ -308,6 +308,8 @@ private:
     const uint8_t n_chromosomes;
     const unordered_map<string,vector<interval_t>>& tandem_track;
     size_t n_vcf_records;
+    string main_chromosome;  // The CHROM field of every VCF record
+    int32_t main_chromosome_length;
     unordered_set<string> bnd_ids;  // ID field of every BND record
 
     /**

--- a/inc/VariantGraph.hpp
+++ b/inc/VariantGraph.hpp
@@ -94,13 +94,17 @@ public:
      */
     void build(vector<VcfRecord>& records, int32_t flank_length, int32_t interior_flank_length = INT32_MAX, bool deallocate_ref_alt = false, const vector<string>& callers = {});
 
-
     /**
-     * Builds a trivial graph that contains one node for string `chromosome[p..q)` (zero-based) and two nodes for
-     * the flanking sequences.
+     * Builds a trivial graph that contains one node for string `chromosome[p..q)` (zero-based) and one node for each
+     * of its flanking sequences (if they exist).
      */
     void build(const string& chromosome, int32_t p, int32_t q, int32_t flank_length);
 
+    /**
+     * @return TRUE iff a graph built from `records` would contain at least one non-reference edge.
+     * This can be useful for deciding which `build()` function to call.
+     */
+    bool would_graph_be_nontrivial(vector<VcfRecord>& records);
 
     /**
      * Serializes the bidirected graph, including paths, if any.

--- a/src/VariantGraph.cpp
+++ b/src/VariantGraph.cpp
@@ -428,7 +428,7 @@ void VariantGraph::build(const string& chromosome, int32_t p, int32_t q, int32_t
     main_chromosome_length=(int32_t)main_chromosome_sequence.length();
     if (p<0 || p>=main_chromosome_length) throw runtime_error("Invalid p");
     if (q<0 || q>=main_chromosome_length) throw runtime_error("Invalid q");
-    if (p>q) throw runtime_error("Invalid p and q");
+    if (p>=q) throw runtime_error("Invalid p and q");
 
     graph.clear();
     n_vcf_records=0; vcf_records.clear();

--- a/src/VariantGraph.cpp
+++ b/src/VariantGraph.cpp
@@ -86,11 +86,11 @@ bool VariantGraph::intersect(const interval_t& interval1, const interval_t& inte
 int32_t VariantGraph::get_flank_boundary_right(const string& chromosome_id, int32_t pos, int32_t flank_length) {
     const auto CHROMOSOME_LENGTH = (int32_t)chromosomes.at(chromosome_id).length();
     if (pos==CHROMOSOME_LENGTH-1) return INT32_MAX;
-    if (!tandem_track.contains(chromosome_id)) return min(pos+flank_length,CHROMOSOME_LENGTH-1);
+    if (!tandem_track.contains(chromosome_id)) return min(pos+flank_length-1,CHROMOSOME_LENGTH-1);
     const vector<interval_t>& intervals = tandem_track.at(chromosome_id);
     const size_t N_INTERVALS = intervals.size();
-    if (N_INTERVALS==0) return min(pos+flank_length,CHROMOSOME_LENGTH-1);
-    tmp_interval.first=pos+1; tmp_interval.second=pos+1+flank_length;
+    if (N_INTERVALS==0) return min(pos+flank_length-1,CHROMOSOME_LENGTH-1);
+    tmp_interval.first=pos; tmp_interval.second=pos+flank_length;
     auto iter = std::lower_bound(intervals.begin(),intervals.end(),tmp_interval);
     size_t p = iter-intervals.begin();
     if (p>0 && intersect(tmp_interval,intervals.at(p-1))) {
@@ -134,15 +134,16 @@ int32_t VariantGraph::get_flank_boundary_left(const string& chromosome_id, int32
 
 void VariantGraph::build(vector<VcfRecord>& records, int32_t flank_length, int32_t interior_flank_length, bool deallocate_ref_alt, const vector<string>& callers) {
     graph.clear();
-    this->vcf_records=std::move(records);
-    n_vcf_records=vcf_records.size();
-    bnd_ids.clear(); bnd_ids.reserve(n_vcf_records);
-    node_handles.clear(); node_handles.reserve(n_chromosomes);
+    n_vcf_records=records.size();
+    if (n_vcf_records!=0) this->vcf_records=std::move(records);
+    else this->vcf_records.clear();
+    bnd_ids.clear(); if (n_vcf_records!=0) bnd_ids.reserve(n_vcf_records);
+    node_handles.clear(); if (n_vcf_records!=0) node_handles.reserve(n_chromosomes);
     for (const auto& chromosome: chromosomes) node_handles.emplace(chromosome.first,vector<handle_t>());
-    node_to_chromosome.clear(); node_to_chromosome.reserve(n_vcf_records);
-    insertion_handles.clear(); insertion_handles.reserve(n_vcf_records);
-    edge_to_vcf_record.clear(); edge_to_vcf_record.reserve(n_vcf_records);
-    if (vcf_records.empty()) { vcf_record_to_edge.clear(); return; }
+    node_to_chromosome.clear(); if (n_vcf_records!=0) node_to_chromosome.reserve(n_vcf_records);
+    insertion_handles.clear(); if (n_vcf_records!=0) insertion_handles.reserve(n_vcf_records);
+    edge_to_vcf_record.clear(); if (n_vcf_records!=0) edge_to_vcf_record.reserve(n_vcf_records);
+    if (n_vcf_records==0) { vcf_record_to_edge.clear(); return; }
 
     const string CHROMOSOME_ID = vcf_records.at(0).chrom;
     const auto CHROMOSOME_LENGTH = (int32_t)chromosomes.at(CHROMOSOME_ID).length();
@@ -420,6 +421,62 @@ void VariantGraph::build(vector<VcfRecord>& records, int32_t flank_length, int32
 }
 
 
+void VariantGraph::build(const string& chromosome, int32_t p, int32_t q, int32_t flank_length) {
+    graph.clear();
+    n_vcf_records=0;
+    bnd_ids.clear();
+    node_handles.clear();
+    for (const auto& chromosome: chromosomes) node_handles.emplace(chromosome.first,vector<handle_t>());
+    node_to_chromosome.clear();
+    insertion_handles.clear(); insertion_handles_set.clear();
+    edge_to_vcf_record.clear(); vcf_record_to_edge.clear();
+
+    bool previous_handle_exists;
+    int32_t first_pos, last_pos;
+    handle_t previous_handle;
+    vector<int32_t> first_positions;
+    const string& chrom_sequence = chromosomes.at(chromosome);
+    const auto CHROMOSOME_LENGTH = (int32_t)chrom_sequence.length();
+
+    vector<handle_t>& handles = node_handles.at(chromosome);
+    handles.clear();
+
+    // Left flank
+    first_pos=get_flank_boundary_left(chromosome,p,flank_length);
+    if (first_pos==INT32_MAX) first_pos=0;
+    if (p!=first_pos) {
+        const handle_t reference_handle = graph.create_handle(chrom_sequence.substr(first_pos,p-first_pos));
+        handles.emplace_back(reference_handle);
+        first_positions.emplace_back(first_pos);
+        node_to_chromosome[graph.get_id(reference_handle)]=pair<string,int32_t>(chromosome,first_pos);
+        previous_handle_exists=true; previous_handle=reference_handle;
+    }
+    else previous_handle_exists=false;
+
+    // Window
+    const handle_t reference_handle = graph.create_handle(chrom_sequence.substr(p,q-p));
+    handles.emplace_back(reference_handle);
+    first_positions.emplace_back(p);
+    node_to_chromosome[graph.get_id(reference_handle)]=pair<string,int32_t>(chromosome,p);
+    if (previous_handle_exists) graph.create_edge(previous_handle,reference_handle);
+    previous_handle_exists=true; previous_handle=reference_handle;
+
+    // Right flank
+    if (q<CHROMOSOME_LENGTH) {
+        last_pos=get_flank_boundary_right(chromosome,q,flank_length);
+        if (last_pos==INT32_MAX) last_pos=(int32_t)(CHROMOSOME_LENGTH-1);
+        const handle_t reference_handle = graph.create_handle(chrom_sequence.substr(q,last_pos+1-q));
+        handles.emplace_back(reference_handle);
+        first_positions.emplace_back(q);
+        node_to_chromosome[graph.get_id(reference_handle)]=pair<string,int32_t>(chromosome,q);
+        graph.create_edge(previous_handle,reference_handle);
+    }
+
+    chunk_first.clear(); chunk_first.emplace(chromosome,first_positions);
+    vcf_record_to_edge.clear();
+}
+
+
 void VariantGraph::to_gfa(const path& gfa_path) const {
     ofstream outstream(gfa_path.string());
     if (!outstream.good() || !outstream.is_open()) throw runtime_error("ERROR: file could not be written: " + gfa_path.string());
@@ -518,7 +575,7 @@ vector<string> VariantGraph::load_gfa(const path& gfa_path) {
         else {  /* No other field is used */ }
         if (c==GFA_LINE_END) {
             if (is_node) graph.create_handle(node_sequence,id_from);
-            else if (is_link) graph.create_edge(orientation_from?graph.get_handle(id_from):graph.flip(graph.get_handle(id_from)),orientation_to?graph.get_handle(id_to):graph.flip(graph.get_handle(id_to)));
+            else if (is_link) graph.create_edge(graph.get_handle(id_from,!orientation_from),graph.get_handle(id_to,!orientation_to));
             else if (is_path) load_gfa_path(path_encoding,node_ids,path_name,buffer);
             n_fields=0;
         }
@@ -543,7 +600,7 @@ path_handle_t VariantGraph::load_gfa_path(const string& path_encoding, const vec
         else if (c!=GFA_FWD_CHAR && c!=GFA_REV_CHAR) { buffer.push_back(c); continue; }
         const auto iterator = lower_bound(node_ids.begin(),node_ids.end(),buffer);
         node_id=distance(node_ids.begin(),iterator)+1;  // Node IDs cannot be zero
-        graph.append_step(path,c==GFA_FWD_CHAR?graph.get_handle(node_id):graph.flip(graph.get_handle(node_id)));
+        graph.append_step(path,graph.get_handle(node_id,c==GFA_REV_CHAR));
         buffer.clear();
     }
     return path;
@@ -1029,7 +1086,7 @@ void VariantGraph::for_each_vcf_record(const vector<pair<string,bool>>& path, co
     for (i=1; i<LENGTH; i++) {
         node_id_from=stoi(path.at(i-1).first); is_reverse_from=path.at(i-1).second;
         node_id_to=stoi(path.at(i).first); is_reverse_to=path.at(i).second;
-        edges.emplace_back(graph.edge_handle(is_reverse_from?graph.flip(graph.get_handle(node_id_from)):graph.get_handle(node_id_from),is_reverse_to?graph.flip(graph.get_handle(node_id_to)):graph.get_handle(node_id_to)));
+        edges.emplace_back(graph.edge_handle(graph.get_handle(node_id_from,is_reverse_from),graph.get_handle(node_id_to,is_reverse_to)));
     }
     get_vcf_records_with_edges_impl(edges,false,ids);
     edges.clear();
@@ -1053,14 +1110,14 @@ path_handle_t VariantGraph::load_gaf_path(const string& path_encoding, const str
         c=path_encoding.at(i);
         if (c==GAF_FWD_CHAR || c==GAF_REV_CHAR) {
             node_id=stoi(buffer);
-            graph.append_step(path,current_orientation?graph.get_handle(node_id):graph.flip(graph.get_handle(node_id)));
+            graph.append_step(path,graph.get_handle(node_id,!current_orientation));
             current_orientation=c==GAF_FWD_CHAR;
             buffer.clear();
         }
         else buffer.push_back(c);
     }
     node_id=stoi(buffer);
-    graph.append_step(path,current_orientation?graph.get_handle(node_id):graph.flip(graph.get_handle(node_id)));
+    graph.append_step(path,graph.get_handle(node_id,!current_orientation));
     return path;
 }
 
@@ -1072,7 +1129,7 @@ path_handle_t VariantGraph::load_gaf_path(vector<pair<string,bool>>& path, const
     path_handle_t path_handle = graph.create_path_handle(path_name);
     for (size_t i=0; i<LENGTH; i++) {
         node_id=stoi(path.at(i).first);
-        graph.append_step(path_handle,path.at(i).second?graph.flip(graph.get_handle(node_id)):graph.get_handle(node_id));
+        graph.append_step(path_handle,graph.get_handle(node_id,path.at(i).second));
     }
     return path_handle;
 }

--- a/src/test/test_variantgraph.cpp
+++ b/src/test/test_variantgraph.cpp
@@ -1040,6 +1040,7 @@ int main(int argc, char* argv[]) {
     const path TEST_VCF_2 = ROOT_DIR/"test2.vcf";
     const path TEST_GFA = ROOT_DIR/"test.gfa";
     const int32_t FLANK_LENGTH = 10;
+    const int32_t INTERIOR_FLANK_LENGTH = 10;
     const size_t SIGNATURE_N_STEPS = 10;
     const size_t N_REUSE_TESTS = 10;
 
@@ -1071,7 +1072,7 @@ int main(int argc, char* argv[]) {
         auto rng = std::default_random_engine { rd() };
         vector<VcfRecord> records_prime = records;
         std::shuffle(std::begin(records_prime),std::end(records_prime),rng);
-        graph.build(records_prime,FLANK_LENGTH,false,caller_ids);
+        graph.build(records_prime,FLANK_LENGTH,INTERIOR_FLANK_LENGTH,false,caller_ids);
 
         cerr << "Testing print_supported_vcf_records() (all records)...\n";
         ofstream truth_vcf(TRUTH_VCF.string());
@@ -1109,7 +1110,7 @@ int main(int argc, char* argv[]) {
     print_truth_vcf_header(truth_vcf);
     print_truth_vcf(2,false/*Arbitrary*/,truth_vcf);
     truth_vcf.close();
-    graph.build(records,FLANK_LENGTH,false,caller_ids);
+    graph.build(records,FLANK_LENGTH,INTERIOR_FLANK_LENGTH,false,caller_ids);
 
     cerr << "DEL...\n";
     truth_gfa.clear(); truth_gfa.open(TRUTH_GFA.string());
@@ -1255,7 +1256,7 @@ int main(int argc, char* argv[]) {
            ) return;
         records.push_back(record);
     });
-    graph.build(records,FLANK_LENGTH,false,caller_ids);
+    graph.build(records,FLANK_LENGTH,INTERIOR_FLANK_LENGTH,false,caller_ids);
     ofstream test_vcf2(TEST_VCF_2.string());
     print_truth_vcf_header(test_vcf2);
     graph.print_supported_vcf_records(test_vcf2,true,caller_ids);
@@ -1286,7 +1287,7 @@ int main(int argc, char* argv[]) {
            ) return;
         records.push_back(record);
     });
-    graph.build(records,FLANK_LENGTH,false,caller_ids);
+    graph.build(records,FLANK_LENGTH,INTERIOR_FLANK_LENGTH,false,caller_ids);
     truth_gfa.clear(); truth_gfa.open(TRUTH_GFA.string());
     print_truth_gfa(true,true,true,true,true,true,truth_gfa);
     truth_gfa.close();

--- a/src/test/test_variantgraph.cpp
+++ b/src/test/test_variantgraph.cpp
@@ -1133,6 +1133,8 @@ int main(int argc, char* argv[]) {
     const vector<string> caller_ids = get_caller_ids();
     auto rd = std::random_device {};
     VariantGraph graph(chromosomes,tandem_track);
+    vector<VcfRecord> no_records;
+    graph.build(no_records,FLANK_LENGTH,INTERIOR_FLANK_LENGTH,false,caller_ids);  // Testing that build() does not crash with no VCF records
     for (size_t i=0; i<N_REUSE_TESTS; i++) {  // The same VariantGraph class can be reused multiple times
         cerr << "----- REUSE TEST " << std::to_string((i+1)) << " ------\n";
         auto rng = std::default_random_engine { rd() };

--- a/src/test/test_variantgraph.cpp
+++ b/src/test/test_variantgraph.cpp
@@ -692,7 +692,9 @@ unordered_map<string,vector<interval_t>> get_tandem_track() {
 }
 
 
-
+/**
+ * Tests also `is_dangling_node()`, `is_flanking_node()`.
+ */
 void test_is_reference(VariantGraph& graph, const vector<string>& node_labels) {
     const vector<string> reference_nodes = {
             "1_1","1_2","1_3","1_4","1_6","1_7","1_8","1_9","1_10","1_11","1_12","1_13","1_14","1_17","1_18","1_19","1_20","1_21","1_22","1_23","1_24","1_25","1_26","1_28","1_29","1_129","1_130",
@@ -703,6 +705,7 @@ void test_is_reference(VariantGraph& graph, const vector<string>& node_labels) {
     const vector<string> reference_nodes_1_2 = {"1_129","1_130"};
     const vector<string> reference_nodes_2_1 = {"2_40","2_50","2_55","2_58","2_61"};
     const vector<string> reference_nodes_2_2 = {"2_166","2_167","2_172"};
+    const vector<string> reference_nodes_2_3 = {"2_285"};
     const vector<string> reference_nodes_3 = {"3_60","3_67"};
     const vector<string> nonreference_nodes = {"ins1","ins2","ins3","rep1","bnd10","bnd11","bnd12","bnd5","bnd6","bnd7","bnd8","ins0","ins5","rep2","rep3"};
     const vector<pair<string,string>> nonreference_edges = {{"1_2","1_9"},{"1_4","1_13"},{"1_7","1_17"},{"1_3","1_18"},{"1_4","ins1"},{"ins1","1_6"},{"1_9","ins2"},{"ins2","1_10"},{"1_11","ins3"},{"ins3","1_12"},{"1_8","rep1"},{"rep1","1_23"},{"1_26","1_2"},{"bnd10","1_18"},{"1_25","bnd11"},{"bnd12","1_26"},{"2_40","1_3"},{"1_19","2_61"},{"bnd5","1_20"},{"3_67","bnd6"},{"bnd6","1_24"},{"1_129","bnd7"},{"bnd7","3_67"},{"1_130","bnd8"},{"1_13","2_167"},{"ins0","1_1"},{"1_130","ins5"},{"1_12","1_1"},{"1_130","1_130"},{"rep2","1_18"},{"1_129","rep3"},{"2_285","1_1"}};
@@ -775,6 +778,68 @@ void test_is_reference(VariantGraph& graph, const vector<string>& node_labels) {
         edge_t edge = graph.graph.edge_handle(handle_from,handle_to);
         if (graph.is_reference_edge(edge)) throw runtime_error("is_reference_edge() failed on edge "+pair.first+"--"+pair.second);
     }
+
+    // Testing `is_dangling_node()`, `is_flanking_node()`.
+    for (size_t i=0; i<reference_nodes_1_1.size()-1; i++) {
+        nid_t node_id = distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_1_1.at(i)))+1;
+        const handle_t node_handle = graph.graph.get_handle(node_id);
+        if (graph.is_dangling_node(node_handle) || graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_1_1.at(i));
+        if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_1_1.at(i));
+    }
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_1_1.at(reference_nodes_1_1.size()-1)))+1;
+    handle_t node_handle = graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_1_1.at(reference_nodes_1_1.size()-1));
+    if (!graph.is_flanking_node(node_handle) || !graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_1_1.at(reference_nodes_1_1.size()-1));
+
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_1_2.at(0)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_1_2.at(0));
+    if (!graph.is_flanking_node(node_handle) || !graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_1_2.at(0));
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_1_2.at(1)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (graph.is_dangling_node(node_handle) || graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_1_2.at(1));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_1_2.at(1));
+
+    for (size_t i=1; i<reference_nodes_2_1.size()-1; i++) {
+        nid_t node_id = distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_2_1.at(i)))+1;
+        const handle_t node_handle = graph.graph.get_handle(node_id);
+        if (graph.is_dangling_node(node_handle) || graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_1.at(i));
+        if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_1.at(i));
+    }
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_2_1.at(0)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_1.at(0));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_2_1.at(0));
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_2_1.at(reference_nodes_2_1.size()-1)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_1.at(reference_nodes_2_1.size()-1));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_2_1.at(reference_nodes_2_1.size()-1));
+
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_2_2.at(0)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_2.at(0));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_2_2.at(0));
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_2_2.at(1)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (graph.is_dangling_node(node_handle) || graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_2.at(1));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_2_2.at(1));
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_2_2.at(2)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_2.at(2));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_2_2.at(2));
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_2_3.at(0)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_2_3.at(0));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_2_3.at(0));
+
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_3.at(0)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (!graph.is_dangling_node(node_handle) || !graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_3.at(0));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_3.at(0));
+    node_id=distance(node_labels.begin(),lower_bound(node_labels.begin(),node_labels.end(),reference_nodes_3.at(1)))+1;
+    node_handle=graph.graph.get_handle(node_id);
+    if (graph.is_dangling_node(node_handle) || graph.is_dangling_node(node_id)) throw runtime_error("is_dangling_node() failed on node "+reference_nodes_3.at(1));
+    if (graph.is_flanking_node(node_handle) || graph.is_flanking_node(node_id)) throw runtime_error("is_flanking_node() failed on node "+reference_nodes_3.at(1));
 }
 
 
@@ -1038,6 +1103,7 @@ int main(int argc, char* argv[]) {
     const path TRUTH_GFA = ROOT_DIR/"truth.gfa";
     const path TEST_VCF = ROOT_DIR/"test.vcf";
     const path TEST_VCF_2 = ROOT_DIR/"test2.vcf";
+    const path UNSUPPORTED_VCF = ROOT_DIR/"unsupported.vcf";
     const path TEST_GFA = ROOT_DIR/"test.gfa";
     const int32_t FLANK_LENGTH = 10;
     const int32_t INTERIOR_FLANK_LENGTH = 10;
@@ -1080,12 +1146,15 @@ int main(int argc, char* argv[]) {
         print_truth_vcf(1,true/*Arbitrary*/,truth_vcf);
         truth_vcf.close();
         ofstream test_vcf(TEST_VCF.string());
+        ofstream unsupported_vcf(UNSUPPORTED_VCF.string());
         print_truth_vcf_header(test_vcf);
-        graph.print_supported_vcf_records(test_vcf,true,caller_ids);
-        test_vcf.close();
+        print_truth_vcf_header(unsupported_vcf);
+        graph.print_supported_vcf_records(test_vcf,unsupported_vcf,true,caller_ids);
+        test_vcf.close(); unsupported_vcf.close();
         command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | sort > tmp1.txt"); run_command(command);
         command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp2.txt"); run_command(command);
         command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+        command.clear(); command.append("COUNT=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); echo ${COUNT} > tmp1.txt; echo 0 > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
 
         cerr << "Testing to_gfa(): node sequences...\n";
         graph.to_gfa(TEST_GFA);
@@ -1119,13 +1188,14 @@ int main(int argc, char* argv[]) {
     vector<string> node_labels = graph.load_gfa(TRUTH_GFA.string());
     vector<pair<edge_t,size_t>> edge_record_map = get_edge_record_map(graph.graph,node_labels);
     graph.load_edge_record_map(edge_record_map,get_n_vcf_records());
-    ofstream test_vcf(TEST_VCF.string());
-    print_truth_vcf_header(test_vcf);
-    graph.print_supported_vcf_records(test_vcf,false,caller_ids);
-    test_vcf.close();
+    ofstream test_vcf(TEST_VCF.string()); ofstream unsupported_vcf(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf,unsupported_vcf,false,caller_ids);
+    test_vcf.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep 'SVTYPE=DEL' | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+    command.clear(); command.append("COUNT1=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); COUNT2=$( bcftools view --no-header "+TEST_VCF.string()+" | wc -l ); echo $(( ${COUNT1} + ${COUNT2} )) > tmp1.txt; echo "+std::to_string(get_n_vcf_records())+" > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
     test_for_each_vcf_record(graph,TEST_VCF.string());
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep 'SVTYPE=DEL' | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp2.txt"); run_command(command);
@@ -1136,13 +1206,14 @@ int main(int argc, char* argv[]) {
     print_truth_gfa(false,true,false,false,false,false,truth_gfa);
     truth_gfa.close();
     node_labels=graph.load_gfa(TRUTH_GFA.string());
-    test_vcf.clear(); test_vcf.open(TEST_VCF.string());
-    print_truth_vcf_header(test_vcf);
-    graph.print_supported_vcf_records(test_vcf,false,caller_ids);
-    test_vcf.close();
+    test_vcf.clear(); test_vcf.open(TEST_VCF.string()); unsupported_vcf.clear(); unsupported_vcf.open(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf,unsupported_vcf,false,caller_ids);
+    test_vcf.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep 'SVTYPE=INV' | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+    command.clear(); command.append("COUNT1=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); COUNT2=$( bcftools view --no-header "+TEST_VCF.string()+" | wc -l ); echo $(( ${COUNT1} + ${COUNT2} )) > tmp1.txt; echo "+std::to_string(get_n_vcf_records())+" > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
     test_for_each_vcf_record(graph,TEST_VCF.string());
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep 'SVTYPE=INV' | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp2.txt"); run_command(command);
@@ -1153,13 +1224,14 @@ int main(int argc, char* argv[]) {
     print_truth_gfa(false,false,true,false,false,false,truth_gfa);
     truth_gfa.close();
     node_labels=graph.load_gfa(TRUTH_GFA.string());
-    test_vcf.clear(); test_vcf.open(TEST_VCF.string());
-    print_truth_vcf_header(test_vcf);
-    graph.print_supported_vcf_records(test_vcf,false,caller_ids);
-    test_vcf.close();
+    test_vcf.clear(); test_vcf.open(TEST_VCF.string()); unsupported_vcf.clear(); unsupported_vcf.open(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf,unsupported_vcf,false,caller_ids);
+    test_vcf.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep 'SVTYPE=INS' | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+    command.clear(); command.append("COUNT1=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); COUNT2=$( bcftools view --no-header "+TEST_VCF.string()+" | wc -l ); echo $(( ${COUNT1} + ${COUNT2} )) > tmp1.txt; echo "+std::to_string(get_n_vcf_records())+" > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
     test_for_each_vcf_record(graph,TEST_VCF.string());
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep 'SVTYPE=INS' | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | uniq > tmp2.txt"); run_command(command);
@@ -1170,13 +1242,14 @@ int main(int argc, char* argv[]) {
     print_truth_gfa(false,false,false,true,false,false,truth_gfa);
     truth_gfa.close();
     node_labels=graph.load_gfa(TRUTH_GFA.string());
-    test_vcf.clear(); test_vcf.open(TEST_VCF.string());
-    print_truth_vcf_header(test_vcf);
-    graph.print_supported_vcf_records(test_vcf,false,caller_ids);
-    test_vcf.close();
+    test_vcf.clear(); test_vcf.open(TEST_VCF.string()); unsupported_vcf.clear(); unsupported_vcf.open(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf,unsupported_vcf,false,caller_ids);
+    test_vcf.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep rep | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+    command.clear(); command.append("COUNT1=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); COUNT2=$( bcftools view --no-header "+TEST_VCF.string()+" | wc -l ); echo $(( ${COUNT1} + ${COUNT2} )) > tmp1.txt; echo "+std::to_string(get_n_vcf_records())+" > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
     test_for_each_vcf_record(graph,TEST_VCF.string());
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep rep | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | uniq > tmp2.txt"); run_command(command);
@@ -1187,13 +1260,14 @@ int main(int argc, char* argv[]) {
     print_truth_gfa(false,false,false,false,true,false,truth_gfa);
     truth_gfa.close();
     node_labels=graph.load_gfa(TRUTH_GFA.string());
-    test_vcf.clear(); test_vcf.open(TEST_VCF.string());
-    print_truth_vcf_header(test_vcf);
-    graph.print_supported_vcf_records(test_vcf,false,caller_ids);
-    test_vcf.close();
+    test_vcf.clear(); test_vcf.open(TEST_VCF.string()); unsupported_vcf.clear(); unsupported_vcf.open(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf,unsupported_vcf,false,caller_ids);
+    test_vcf.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep -E 'SVTYPE=DUP|bnd19|bnd20' | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+    command.clear(); command.append("COUNT1=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); COUNT2=$( bcftools view --no-header "+TEST_VCF.string()+" | wc -l ); echo $(( ${COUNT1} + ${COUNT2} )) > tmp1.txt; echo "+std::to_string(get_n_vcf_records())+" > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
     test_for_each_vcf_record(graph,TEST_VCF.string());
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep -E 'SVTYPE=DUP|bnd19|bnd20' | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | uniq | cut -f 1,2,3,4,5,6,7,9,10 > tmp2.txt"); run_command(command);
@@ -1204,13 +1278,14 @@ int main(int argc, char* argv[]) {
     print_truth_gfa(false,false,false,false,false,true,truth_gfa);
     truth_gfa.close();
     node_labels=graph.load_gfa(TRUTH_GFA.string());
-    test_vcf.clear(); test_vcf.open(TEST_VCF.string());
-    print_truth_vcf_header(test_vcf);
-    graph.print_supported_vcf_records(test_vcf,false,caller_ids);
-    test_vcf.close();
+    test_vcf.clear(); test_vcf.open(TEST_VCF.string()); unsupported_vcf.clear(); unsupported_vcf.open(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf,unsupported_vcf,false,caller_ids);
+    test_vcf.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep -E 'SVTYPE=BND|dup1' | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+    command.clear(); command.append("COUNT1=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); COUNT2=$( bcftools view --no-header "+TEST_VCF.string()+" | wc -l ); echo $(( ${COUNT1} + ${COUNT2} )) > tmp1.txt; echo "+std::to_string(get_n_vcf_records())+" > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
     test_for_each_vcf_record(graph,TEST_VCF.string());
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | grep -E 'SVTYPE=BND|dup1' | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | uniq | cut -f 1,2,3,4,5,6,7,9,10 > tmp2.txt"); run_command(command);
@@ -1221,13 +1296,14 @@ int main(int argc, char* argv[]) {
     print_truth_gfa(true,true,true,true,true,true,truth_gfa);
     truth_gfa.close();
     node_labels=graph.load_gfa(TRUTH_GFA.string());
-    test_vcf.clear(); test_vcf.open(TEST_VCF.string());
-    print_truth_vcf_header(test_vcf);
-    graph.print_supported_vcf_records(test_vcf,false,caller_ids);
-    test_vcf.close();
+    test_vcf.clear(); test_vcf.open(TEST_VCF.string()); unsupported_vcf.clear(); unsupported_vcf.open(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf,unsupported_vcf,false,caller_ids);
+    test_vcf.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
+    command.clear(); command.append("COUNT1=$( bcftools view --no-header "+UNSUPPORTED_VCF.string()+" | wc -l ); COUNT2=$( bcftools view --no-header "+TEST_VCF.string()+" | wc -l ); echo $(( ${COUNT1} + ${COUNT2} )) > tmp1.txt; echo "+std::to_string(get_n_vcf_records())+" > tmp2.txt; diff --brief tmp1.txt tmp2.txt"); run_command(command);
     test_for_each_vcf_record(graph,TEST_VCF.string());
     command.clear(); command.append("bcftools view --no-header "+TRUTH_VCF.string()+" | sort | cut -f 1,2,3,4,5,6,7,9,10 > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort | uniq | cut -f 1,2,3,4,5,6,7,9,10 > tmp2.txt"); run_command(command);
@@ -1258,9 +1334,10 @@ int main(int argc, char* argv[]) {
     });
     graph.build(records,FLANK_LENGTH,INTERIOR_FLANK_LENGTH,false,caller_ids);
     ofstream test_vcf2(TEST_VCF_2.string());
-    print_truth_vcf_header(test_vcf2);
-    graph.print_supported_vcf_records(test_vcf2,true,caller_ids);
-    test_vcf2.close();
+    unsupported_vcf.clear(); unsupported_vcf.open(UNSUPPORTED_VCF.string());
+    print_truth_vcf_header(test_vcf2); print_truth_vcf_header(unsupported_vcf);
+    graph.print_supported_vcf_records(test_vcf2,unsupported_vcf,true,caller_ids);
+    test_vcf2.close(); unsupported_vcf.close();
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF.string()+" | sort > tmp1.txt"); run_command(command);
     command.clear(); command.append("bcftools view --no-header "+TEST_VCF_2.string()+" | sort > tmp2.txt"); run_command(command);
     command.clear(); command.append("diff --brief tmp1.txt tmp2.txt"); run_command(command);
@@ -1272,6 +1349,7 @@ int main(int argc, char* argv[]) {
     node_labels=graph.load_gfa(TRUTH_GFA.string());
     edge_record_map=get_edge_record_map(graph.graph,node_labels);
     graph.load_edge_record_map(edge_record_map,get_n_vcf_records());
+    graph.node_to_chromosome_clear(); node_to_chromosome_insert(graph,node_labels);
     test_is_reference(graph,node_labels);
 
     cerr << "Testing vcf_records_with_edges()...\n";
@@ -1297,5 +1375,5 @@ int main(int argc, char* argv[]) {
     test_vcf_records_with_edges(graph,node_labels);
 
     cerr << "Removing temporary files...\n";
-    command.clear(); command.append("rm -f truth*.vcf test*.vcf truth*.gfa test*.gfa tmp*.txt"); run_command(command);
+    command.clear(); command.append("rm -f input*.vcf truth*.vcf test*.vcf unsupported*.vcf truth*.gfa test*.gfa tmp*.txt"); run_command(command);
 }


### PR DESCRIPTION
And moreover:
- added support for empty `tandem_track` (default), and clearer documentation;
- added defaults to some `build()` arguments;
- added `if (not file.good() or not file.is_open())` everywhere a stream is opened in `VariantGraph`;
- fixed GFA overlap field.
