### PR TITLE
BND support for annotation

### DIFF
--- a/inc/VcfReader.hpp
+++ b/inc/VcfReader.hpp
@@ -224,6 +224,12 @@ public:
     void get_breakend_inserted_sequence(string& out) const;
 
     /**
+     * Every BND that involves two positions should have a mate, i.e. a symmetrical record at the other position.
+     * This function sets `out` to the ALT field of the mate of this record, which is assumed to be BND.
+     */
+    void get_alt_of_breakend_mate(const unordered_map<string,string>& chromosomes, string& out);
+
+    /**
      * Checks the IMPRECISE tag and the confidence intervals fields.
      */
     bool is_precise();
@@ -251,6 +257,12 @@ public:
      * `sv_length`, if available.
      */
     void get_reference_coordinates(bool use_confidence_intervals, coord_t& out);
+
+    /**
+     * @return TRUE iff the ALT field represents a regular (non-virtual) or a single BND. Some callers might emit ALTs
+     * that do not conform to the VCF spec (e.g. sniffles can output `ACNNNNNNNNNNNNNNN` in the ALT of a BND).
+     */
+    bool is_valid_bnd_alt();
 
 private:
     /**
@@ -321,6 +333,7 @@ public:
     static const char PHASED_CHAR;
     static const string CHR_STR_LOWER;
     static const string CHR_STR_UPPER;
+    static const char UNKNOWN_BASE;
 
     /**
      * Info field constants

--- a/inc/VcfReader.hpp
+++ b/inc/VcfReader.hpp
@@ -319,6 +319,8 @@ public:
     static const char BREAKEND_SEPARATOR;
     static const char UNPHASED_CHAR;
     static const char PHASED_CHAR;
+    static const string CHR_STR_LOWER;
+    static const string CHR_STR_UPPER;
 
     /**
      * Info field constants

--- a/inc/VcfReader.hpp
+++ b/inc/VcfReader.hpp
@@ -225,7 +225,7 @@ public:
 
     /**
      * Every BND that involves two positions should have a mate, i.e. a symmetrical record at the other position.
-     * This function sets `out` to the ALT field of the mate of this record, which is assumed to be BND.
+     * This function sets `out` to the ALT field of the mate of this record, which is assumed to be a BND.
      */
     void get_alt_of_breakend_mate(const unordered_map<string,string>& chromosomes, string& out);
 
@@ -321,6 +321,7 @@ public:
     static const char LINE_END;
     static const char VCF_SEPARATOR;
     static const char VCF_MISSING_CHAR;
+    static const string VCF_MISSING_STRING;
     static const char SYMBOLIC_CHAR_OPEN;
     static const char SYMBOLIC_CHAR_CLOSE;
     static const char BREAKEND_CHAR_OPEN;

--- a/inc/VcfReader.hpp
+++ b/inc/VcfReader.hpp
@@ -58,7 +58,7 @@ public:
      * Remark: `pass_only` means FILTER=PASS or FILTER='.'
      */
     bool pass_only, high_qual_only;
-    int32_t min_sv_length, n_samples_to_load;
+    int32_t min_sv_length, max_sv_length, n_samples_to_load;
     double min_qual, min_af, min_nmf;
 
     /**
@@ -91,10 +91,12 @@ public:
      * @param pass_only calls with FILTER different from PASS or `.` are discarded by the user;
      * @param high_qual_only calls with `QUAL<min_qual` are discarded by the user;
      * @param min_sv_length calls shorter than this are discarded by the user;
+     * @param max_sv_length calls longer than this are discarded by the user; a better approach consists in pre-
+     * processing the VCF to transform every large call into a set of BNDs: see `clean_bnds.cpp`;
      * @param min_af calls with too few haplotypes containing the ALT allele are discarded by the user;
      * @param min_nmf calls with too few non-missing haplotypes are discarded by the user.
      */
-    VcfRecord(bool high_qual_only, double min_qual, bool pass_only, int32_t min_sv_length, int32_t n_samples_to_load, double min_af, double min_nmf);
+    VcfRecord(bool high_qual_only, double min_qual, bool pass_only, int32_t min_sv_length, int32_t max_sv_length, int32_t n_samples_to_load, double min_af, double min_nmf);
 
     /**
      * @return a new object that contains a copy of every variable of the current object that was loaded from a VCF
@@ -110,7 +112,7 @@ public:
      * - If `high_qual_only` is true and the call has low quality, no field after QUAL is loaded.
      * - If `pass_only` is true and the call is not PASS, no field after FILTER is loaded.
      * - If the call is not of a supported type, no field after INFO is loaded.
-     * - If the call is shorter than `min_sv_length`, no field after INFO is loaded.
+     * - If the call is shorter than `min_sv_length` or longer than `max_sv_length`, no field after INFO is loaded.
      * - If there are more samples than `n_samples_to_load`, no sample after the maximum is loaded.
      */
     void set_from_stream(ifstream& stream);
@@ -298,7 +300,7 @@ private:
      *
      * @return TRUE iff some VCF fields were skipped.
      */
-    bool set_field(const string& field, int32_t field_id, bool high_qual_only, double min_qual, bool pass_only, int32_t min_sv_length, double min_af, double min_nmf, ifstream& stream, string& tmp_buffer, pair<uint8_t, uint8_t>& tmp_pair);
+    bool set_field(const string& field, int32_t field_id, bool high_qual_only, double min_qual, bool pass_only, int32_t min_sv_length, int32_t max_sv_length, double min_af, double min_nmf, ifstream& stream, string& tmp_buffer, pair<uint8_t, uint8_t>& tmp_pair);
 
     /**
      * Core logic of confidence intervals extraction
@@ -395,7 +397,7 @@ public:
     bool high_qual_only;
     double min_qual;
     bool pass_only;
-    int32_t min_sv_length;
+    int32_t min_sv_length, max_sv_length;
     int32_t n_samples_to_load;  // A prefix of the list of all samples. 0=do not load any sample. MAX=load all samples.
     double min_allele_frequency;
     double min_nonmissing_frequency;
@@ -410,7 +412,7 @@ public:
      * @param path a VCF file that contains only calls in `chromosome`;
      * @param progress_n_lines prints a progress message to STDERR after this number of lines have been read (0=silent).
      */
-    VcfReader(const path& vcf_path, int32_t progress_n_lines, bool high_qual_only, double min_qual, bool pass_only, int32_t min_sv_length, int32_t n_samples_to_load, double min_allele_frequency, double min_nonmissing_frequency);
+    VcfReader(const path& vcf_path, int32_t progress_n_lines, bool high_qual_only, double min_qual, bool pass_only, int32_t min_sv_length, int32_t max_sv_length, int32_t n_samples_to_load, double min_allele_frequency, double min_nonmissing_frequency);
     VcfReader(const path& vcf_path);
 
     /**

--- a/inc/fetch.hpp
+++ b/inc/fetch.hpp
@@ -12,8 +12,8 @@
 #include "bed.hpp"
 #include "bam.hpp"
 
-#include "bindings/cpp/WFAligner.hpp"
-using namespace wfa;
+// #include "bindings/cpp/WFAligner.hpp"
+// using namespace wfa;
 
 #include <unordered_map>
 #include <exception>

--- a/inc/fetch.hpp
+++ b/inc/fetch.hpp
@@ -55,7 +55,8 @@ void fetch_reads(
         bool require_spanning,
         bool append_sample_to_read = false,
         bool force_forward = false,
-        bool get_qualities = false
+        bool get_qualities = false,
+        int32_t max_clip_fetch = 0
 );
 
 
@@ -73,6 +74,7 @@ void fetch_reads(
  * @param first_only only consider the first read observed for each window in the BAM (for omitting misassemblies in asm-to-ref BAMs)
  * @param append_sample_to_read if true, attempt to force unique read names by using their sample name as a suffix
  * @param force_forward if true, complement reverse sequences so they are given in ref forward orientation
+ * @param max_clip_fetch if non-zero, attempt to fetch this many clipped bases beyond the end of non-spanning sequences
  */
 void fetch_reads_from_clipped_bam(
         Timer& t,
@@ -86,7 +88,8 @@ void fetch_reads_from_clipped_bam(
         bool get_flank_query_coords = false,
         bool first_only = false,
         bool append_sample_to_read = false,
-        bool force_forward = false
+        bool force_forward = false,
+        int32_t max_clip_fetch = 0
 );
 
 
@@ -112,19 +115,6 @@ void extract_flanked_subregion_coords_from_sample(
 );
 
 
-void get_read_coords_for_each_subregion_in_bam(
-        Timer& t,
-        vector<Region>& regions,
-        GoogleAuthenticator& authenticator,
-        sample_region_flanked_coord_map_t& sample_to_region_coords,
-        path bam,
-        int64_t n_threads,
-        int32_t flank_length,
-        bool require_spanning,
-        bool get_flank_query_coords
-);
-
-
 void extract_subsequences_from_sample_thread_fn(
         GoogleAuthenticator& authenticator,
         sample_region_read_map_t& sample_to_region_reads,
@@ -135,7 +125,8 @@ void extract_subsequences_from_sample_thread_fn(
         bool get_qualities,
         atomic<size_t>& job_index,
         const vector<string>& tags_to_fetch = {},
-        bool allow_unused_tags = false
+        bool allow_unused_tags = false,
+        int32_t max_clip_fetch = 0
 );
 
 

--- a/src/VariantGraph.cpp
+++ b/src/VariantGraph.cpp
@@ -94,27 +94,28 @@ int32_t VariantGraph::get_flank_boundary_right(const string& chromosome_id, int3
 
 
 int32_t VariantGraph::get_flank_boundary_right_impl(int32_t pos, int32_t sequence_length, const vector<interval_t>& intervals, int32_t flank_length) {
-cerr << "get_flank_boundary_right_impl> 1 \n";
+bool verbose = false;
+if (verbose) cerr << "get_flank_boundary_right_impl> 1 \n";
     const size_t N_INTERVALS = intervals.size();
-cerr << "get_flank_boundary_right_impl> 2  N_INTERVALS=" << N_INTERVALS << " \n";
+if (verbose) cerr << "get_flank_boundary_right_impl> 2  N_INTERVALS=" << N_INTERVALS << " \n";
     if (N_INTERVALS==0) return min(pos+flank_length-1,sequence_length-1);
     tmp_interval.first=pos; tmp_interval.second=pos+flank_length;
-cerr << "get_flank_boundary_right_impl> 3  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
+if (verbose) cerr << "get_flank_boundary_right_impl> 3  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     auto iter = std::lower_bound(intervals.begin(),intervals.end(),tmp_interval);
     size_t p = iter-intervals.begin();
-cerr << "get_flank_boundary_right_impl> 4  p=" << p << "\n";
+if (verbose) cerr << "get_flank_boundary_right_impl> 4  p=" << p << "\n";
     if (p>0 && intersect(tmp_interval,intervals.at(p-1))) {
         tmp_interval.first=intervals.at(p-1).second;
         tmp_interval.second=tmp_interval.first+flank_length;
-cerr << "get_flank_boundary_right_impl> 5  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
+if (verbose) cerr << "get_flank_boundary_right_impl> 5  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     }
     while (p<N_INTERVALS && intersect(tmp_interval,intervals.at(p))) {
         tmp_interval.first=intervals.at(p).second;
         tmp_interval.second=tmp_interval.first+flank_length;
-cerr << "get_flank_boundary_right_impl> 6  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
+if (verbose) cerr << "get_flank_boundary_right_impl> 6  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
         p++;
     }
-cerr << "get_flank_boundary_right_impl> 7  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
+if (verbose) cerr << "get_flank_boundary_right_impl> 7  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     return tmp_interval.first>=sequence_length?INT32_MAX:min(tmp_interval.second-1,sequence_length-1);
 }
 
@@ -128,44 +129,46 @@ int32_t VariantGraph::get_flank_boundary_left(const string& chromosome_id, int32
 
 
 int32_t VariantGraph::get_flank_boundary_left_impl(int32_t pos, const vector<interval_t>& intervals, int32_t flank_length) {
-cerr << "get_flank_boundary_left_impl> 1 \n";
+bool verbose = false;
+if (verbose) cerr << "get_flank_boundary_left_impl> 1 \n";
     const size_t N_INTERVALS = intervals.size();
-cerr << "get_flank_boundary_left_impl> 1.1 \n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 1.1 \n";
     if (N_INTERVALS==0) return pos>=flank_length?pos-flank_length:0;
-cerr << "get_flank_boundary_left_impl> 1.2 \n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 1.2 \n";
     tmp_interval.first=pos>=flank_length?pos-flank_length:0; tmp_interval.second=pos;
-cerr << "get_flank_boundary_left_impl> 1.3  N_INTERVALS=" << N_INTERVALS << "\n";
-cerr << "intervals.at(0)=" << intervals.at(0).first << "," << intervals.at(0).second << "\n";
-cerr << "intervals.begin()=" << intervals.begin()->first << "," << intervals.begin()->second << "\n";
-cerr << "intervals.end()=" << intervals.end()->first << "," << intervals.end()->second << "\n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 1.3  N_INTERVALS=" << N_INTERVALS << "\n";
+if (verbose) cerr << "intervals.at(0)=" << intervals.at(0).first << "," << intervals.at(0).second << "\n";
+if (verbose) cerr << "intervals.begin()=" << intervals.begin()->first << "," << intervals.begin()->second << "\n";
+if (verbose) cerr << "intervals.end()=" << intervals.end()->first << "," << intervals.end()->second << "\n";
     auto iter = std::lower_bound(intervals.begin(),intervals.end(),tmp_interval);
-cerr << "get_flank_boundary_left_impl> 1.4 \n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 1.4 \n";
     size_t p = iter-intervals.begin();
-cerr << "get_flank_boundary_left_impl> 2  p=" << p << "\n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 2  p=" << p << "\n";
     if (p<N_INTERVALS && intersect(tmp_interval,intervals.at(p))) {
-cerr << "get_flank_boundary_left_impl> 3 \n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 3 \n";
         tmp_interval.second=intervals.at(p).first;
         tmp_interval.first=tmp_interval.second>=flank_length?tmp_interval.second-flank_length:0;
     }
     if (p>0) {
-cerr << "get_flank_boundary_left_impl> 4 \n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 4 \n";
         p--;
         while (intersect(tmp_interval,intervals.at(p))) {
-cerr << "get_flank_boundary_left_impl> 5  p=" << p << "\n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 5  p=" << p << "\n";
             tmp_interval.second=intervals.at(p).first;
             tmp_interval.first=tmp_interval.second>=flank_length?tmp_interval.second-flank_length:0;
             if (p==0) break;
             else p--;
         }
-cerr << "get_flank_boundary_left_impl> 6 \n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 6 \n";
     }
-cerr << "get_flank_boundary_left_impl> 7 \n";
+if (verbose) cerr << "get_flank_boundary_left_impl> 7 \n";
     return tmp_interval.second==0?INT32_MAX:tmp_interval.first;
 }
 
 
 void VariantGraph::get_tandem_intervals(nid_t node_id, int32_t node_length, bool is_reverse, int32_t offset, vector<interval_t>& out) {
     size_t i, from;
+bool verbose = false;
 
     const auto OUT_FIRST = out.size();
     const pair<string,int32_t> COORDINATE = node_to_chromosome.find(node_id)->second;
@@ -188,30 +191,30 @@ void VariantGraph::get_tandem_intervals(nid_t node_id, int32_t node_length, bool
     while (i<N_INTERVALS) {
         if (INTERVALS.at(i).first>=tmp_interval.second) break;
         out.emplace_back(max(tmp_interval.first,INTERVALS.at(i).first),min(tmp_interval.second,INTERVALS.at(i).second));
-cerr << "get_tandem_intervals of node> 1  emplaced back " << max(tmp_interval.first,INTERVALS.at(i).first) << ", " << min(tmp_interval.second,INTERVALS.at(i).second) << "\n";
+if (verbose) cerr << "get_tandem_intervals of node> 1  emplaced back " << max(tmp_interval.first,INTERVALS.at(i).first) << ", " << min(tmp_interval.second,INTERVALS.at(i).second) << "\n";
         i++;
     }
     if (!is_reverse) {
-cerr << "get_tandem_intervals of node> 2.0  \n";
+if (verbose) cerr << "get_tandem_intervals of node> 2.0  \n";
         for (i=OUT_FIRST; i<out.size(); i++) {
-cerr << "get_tandem_intervals of node> 2.1 \n";
+if (verbose) cerr << "get_tandem_intervals of node> 2.1 \n";
             out.at(i).first=out.at(i).first-tmp_interval.first+offset;
             out.at(i).second=out.at(i).second-tmp_interval.first+offset;
-cerr << "get_tandem_intervals of node> 2.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
+if (verbose) cerr << "get_tandem_intervals of node> 2.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
         }
     }
     else {
-cerr << "get_tandem_intervals of node> 3.0 \n";
+if (verbose) cerr << "get_tandem_intervals of node> 3.0 \n";
         std::reverse(out.begin()+OUT_FIRST,out.end());
         for (i=OUT_FIRST; i<out.size(); i++) {
-cerr << "get_tandem_intervals of node> 3.1 \n";
+if (verbose) cerr << "get_tandem_intervals of node> 3.1 \n";
             std::swap(out.at(i).first,out.at(i).second);
             out.at(i).first=(tmp_interval.second-1)-(out.at(i).first-1)+offset;
             out.at(i).second=(tmp_interval.second-1)-(out.at(i).second-1)+offset;
-cerr << "get_tandem_intervals of node> 3.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
+if (verbose) cerr << "get_tandem_intervals of node> 3.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
         }
     }
-cerr << "get_tandem_intervals of node> 4 \n";
+if (verbose) cerr << "get_tandem_intervals of node> 4 \n";
 }
 
 
@@ -220,31 +223,32 @@ void VariantGraph::get_tandem_intervals(const vector<nid_t>& node_ids, const vec
     size_t i, j;
     int32_t offset, length, length_prime;
     nid_t node_id;
+bool verbose = false;
 
     // Collecting per-node tandem intervals, including entire non-ref nodes.
     out.clear(); offset=0; i=0;
     while (i<LENGTH) {
-cerr << "get_tandem_intervals> 1  i=" << i << " LENGTH=" << LENGTH << "\n";
+if (verbose) cerr << "get_tandem_intervals> 1  i=" << i << " LENGTH=" << LENGTH << "\n";
         node_id=node_ids.at(i);
         length=node_lengths.at(i);
         if (is_reference_node(node_id)) {
-cerr << "get_tandem_intervals> 2 \n";
+if (verbose) cerr << "get_tandem_intervals> 2 \n";
             get_tandem_intervals(node_id,length,is_reverse.at(i),offset,out);
             offset+=length;
             i++;
-cerr << "get_tandem_intervals> 3  i=" << i<< "\n";
+if (verbose) cerr << "get_tandem_intervals> 3  i=" << i<< "\n";
         }
         else {
-cerr << "get_tandem_intervals> 4 \n";
+if (verbose) cerr << "get_tandem_intervals> 4 \n";
             if (!out.empty() && out.at(out.size()-1).second==offset) {
-cerr << "get_tandem_intervals> 5 \n";
+if (verbose) cerr << "get_tandem_intervals> 5 \n";
                 out.at(out.size()-1).second=offset+length;
                 offset+=length;
                 i++;
-cerr << "get_tandem_intervals> 6 \n";
+if (verbose) cerr << "get_tandem_intervals> 6 \n";
             }
             else if (i<LENGTH-1) {
-cerr << "get_tandem_intervals> 7 \n";
+if (verbose) cerr << "get_tandem_intervals> 7 \n";
                 j=out.size();
                 i++;
                 node_id=node_ids.at(i);
@@ -254,7 +258,7 @@ cerr << "get_tandem_intervals> 7 \n";
                 if (out.size()>j && out.at(j).first==offset+length) out.at(j).first=offset;
                 offset+=length+length_prime;
                 i++;
-cerr << "get_tandem_intervals> 8  i=" << i << "\n";
+if (verbose) cerr << "get_tandem_intervals> 8  i=" << i << "\n";
             }
             else {
                 offset+=length;
@@ -288,8 +292,9 @@ void VariantGraph::vcf_record_to_path_intervals(const vector<pair<string,bool>>&
     int32_t length, path_length_bps;
     nid_t id;
     handle_t handle1, handle2;
+bool verbose = false;
 
-cerr << "vcf_record_to_path_intervals> 1 \n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 1 \n";
     node_ids_buffer.clear(); is_reverse_buffer.clear(); node_lengths_buffer.clear(); tmp_edges.clear();
     id=stoll(path.at(0).first);
     rev=path.at(0).second;
@@ -311,13 +316,13 @@ cerr << "vcf_record_to_path_intervals> 1 \n";
         tmp_edges.emplace_back(graph.edge_handle(handle1,handle2));  // Canonized
         handle1=handle2;
     }
-cerr << "vcf_record_to_path_intervals> 2 \n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 2 \n";
     get_tandem_intervals(node_ids_buffer,is_reverse_buffer,node_lengths_buffer,intervals_buffer);
-cerr << "vcf_record_to_path_intervals> 3  tandem intervals: \n";
-for (i=0; i<intervals_buffer.size(); i++) cerr << intervals_buffer.at(i).first << ".." << intervals_buffer.at(i).second << "\n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 3  tandem intervals: \n";
+if (verbose) for (i=0; i<intervals_buffer.size(); i++) cerr << intervals_buffer.at(i).first << ".." << intervals_buffer.at(i).second << "\n";
     out.clear(); x=0;
     for (i=0; i<PATH_LENGTH-1; i++) {
-cerr << "vcf_record_to_path_intervals> 4 \n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 4 \n";
         x+=node_lengths_buffer.at(i);
         found=false;
         if (tmp_edges.at(i)==edges_of_the_record.at(0)) {
@@ -330,7 +335,7 @@ cerr << "vcf_record_to_path_intervals> 4 \n";
             }
             if (p==N_EDGES) found=true;
         }
-cerr << "vcf_record_to_path_intervals> 5 \n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 5 \n";
         if (!found && tmp_edges.at(i)==edges_of_the_record.at(N_EDGES-1)) {
             // Reverse match
             j=i; p=N_EDGES-2; y=x;
@@ -342,19 +347,19 @@ cerr << "vcf_record_to_path_intervals> 5 \n";
             if (p==-1) found=true;
         }
         if (found) {
-cerr << "vcf_record_to_path_intervals> 6  x=" << x << " y=" << y << " interval length=" << (y-x) << "  intervals_buffer.size()=" << intervals_buffer.size() << "\n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 6  x=" << x << " y=" << y << " interval length=" << (y-x) << "  intervals_buffer.size()=" << intervals_buffer.size() << "\n";
 int32_t left = get_flank_boundary_left_impl(x,intervals_buffer,flank_length);
 if (left==INT32_MAX) left=0;
-cerr << "vcf_record_to_path_intervals> 7  left=";
-cerr << left << "\n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 7  left=";
+if (verbose) cerr << left << "\n";
 int32_t right = get_flank_boundary_right_impl(y,path_length_bps,intervals_buffer,flank_length);
 if (right==INT32_MAX) right=path_length_bps-1;
-cerr << "vcf_record_to_path_intervals> 8  right=";
-cerr << right << "\n";
-cerr << "new interval length=" << (right-left) << "\n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 8  right=";
+if (verbose) cerr << right << "\n";
+if (verbose) cerr << "new interval length=" << (right-left) << "\n";
             out.emplace_back(left,right);
         }
-cerr << "vcf_record_to_path_intervals> 7 \n";
+if (verbose) cerr << "vcf_record_to_path_intervals> 7 \n";
     }
 }
 
@@ -722,18 +727,19 @@ void VariantGraph::build(const string& chromosome, int32_t p, int32_t q, int32_t
 
 
 bool VariantGraph::would_graph_be_nontrivial(vector<VcfRecord>& records) {
-cerr << "would_graph_be_nontrivial> 1 \n";
+bool verbose = false;
+if (verbose) cerr << "would_graph_be_nontrivial> 1 \n";
     if (records.size()==0) return false;
     pair<int32_t,int32_t> tmp_pair;
     for (auto& record: records) {
-cerr << "would_graph_be_nontrivial> 2 \n";
+if (verbose) cerr << "would_graph_be_nontrivial> 2 \n";
         record.get_reference_coordinates(false,tmp_pair);
-cerr << "would_graph_be_nontrivial> 3 \n";
+if (verbose) cerr << "would_graph_be_nontrivial> 3 \n";
         if (tmp_pair.first==INT32_MAX || tmp_pair.second==INT32_MAX) continue;
-cerr << "would_graph_be_nontrivial> 4 \n";
-cerr << "would_graph_be_nontrivial> record.is_symbolic: " << record.is_symbolic << "\n";
-cerr << "would_graph_be_nontrivial> record.is_breakend_single: " << to_string(record.is_breakend_single()) << "\n";
-cerr << "would_graph_be_nontrivial> record.is_breakend_virtual: " << record.is_breakend_virtual(chromosomes) << "\n";
+if (verbose) cerr << "would_graph_be_nontrivial> 4 \n";
+if (verbose) cerr << "would_graph_be_nontrivial> record.is_symbolic: " << record.is_symbolic << "\n";
+if (verbose) cerr << "would_graph_be_nontrivial> record.is_breakend_single: " << to_string(record.is_breakend_single()) << "\n";
+if (verbose) cerr << "would_graph_be_nontrivial> record.is_breakend_virtual: " << record.is_breakend_virtual(chromosomes) << "\n";
         if ( (record.sv_type==VcfReader::TYPE_INSERTION && !record.is_symbolic) ||
              record.sv_type==VcfReader::TYPE_DELETION ||
              record.sv_type==VcfReader::TYPE_INVERSION ||
@@ -742,12 +748,12 @@ cerr << "would_graph_be_nontrivial> record.is_breakend_virtual: " << record.is_b
              record.sv_type==VcfReader::TYPE_CNV ||
              (record.sv_type==VcfReader::TYPE_BREAKEND && record.is_breakend_single()>=1 && !record.is_breakend_virtual(chromosomes))
              ) {
-cerr << "would_graph_be_nontrivial> 5 \n";
+if (verbose) cerr << "would_graph_be_nontrivial> 5 \n";
             return true;
         }
-cerr << "would_graph_be_nontrivial> 6 \n";
+if (verbose) cerr << "would_graph_be_nontrivial> 6 \n";
     }
-cerr << "would_graph_be_nontrivial> 7 \n";
+if (verbose) cerr << "would_graph_be_nontrivial> 7 \n";
     return false;
 }
 

--- a/src/VariantGraph.cpp
+++ b/src/VariantGraph.cpp
@@ -94,28 +94,20 @@ int32_t VariantGraph::get_flank_boundary_right(const string& chromosome_id, int3
 
 
 int32_t VariantGraph::get_flank_boundary_right_impl(int32_t pos, int32_t sequence_length, const vector<interval_t>& intervals, int32_t flank_length) {
-bool verbose = false;
-if (verbose) cerr << "get_flank_boundary_right_impl> 1 \n";
     const size_t N_INTERVALS = intervals.size();
-if (verbose) cerr << "get_flank_boundary_right_impl> 2  N_INTERVALS=" << N_INTERVALS << " \n";
     if (N_INTERVALS==0) return min(pos+flank_length-1,sequence_length-1);
     tmp_interval.first=pos; tmp_interval.second=pos+flank_length;
-if (verbose) cerr << "get_flank_boundary_right_impl> 3  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     auto iter = std::lower_bound(intervals.begin(),intervals.end(),tmp_interval);
     size_t p = iter-intervals.begin();
-if (verbose) cerr << "get_flank_boundary_right_impl> 4  p=" << p << "\n";
     if (p>0 && intersect(tmp_interval,intervals.at(p-1))) {
         tmp_interval.first=intervals.at(p-1).second;
         tmp_interval.second=tmp_interval.first+flank_length;
-if (verbose) cerr << "get_flank_boundary_right_impl> 5  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     }
     while (p<N_INTERVALS && intersect(tmp_interval,intervals.at(p))) {
         tmp_interval.first=intervals.at(p).second;
         tmp_interval.second=tmp_interval.first+flank_length;
-if (verbose) cerr << "get_flank_boundary_right_impl> 6  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
         p++;
     }
-if (verbose) cerr << "get_flank_boundary_right_impl> 7  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     return tmp_interval.first>=sequence_length?INT32_MAX:min(tmp_interval.second-1,sequence_length-1);
 }
 
@@ -129,46 +121,30 @@ int32_t VariantGraph::get_flank_boundary_left(const string& chromosome_id, int32
 
 
 int32_t VariantGraph::get_flank_boundary_left_impl(int32_t pos, const vector<interval_t>& intervals, int32_t flank_length) {
-bool verbose = false;
-if (verbose) cerr << "get_flank_boundary_left_impl> 1 \n";
     const size_t N_INTERVALS = intervals.size();
-if (verbose) cerr << "get_flank_boundary_left_impl> 1.1 \n";
     if (N_INTERVALS==0) return pos>=flank_length?pos-flank_length:0;
-if (verbose) cerr << "get_flank_boundary_left_impl> 1.2 \n";
     tmp_interval.first=pos>=flank_length?pos-flank_length:0; tmp_interval.second=pos;
-if (verbose) cerr << "get_flank_boundary_left_impl> 1.3  N_INTERVALS=" << N_INTERVALS << "\n";
-if (verbose) cerr << "intervals.at(0)=" << intervals.at(0).first << "," << intervals.at(0).second << "\n";
-if (verbose) cerr << "intervals.begin()=" << intervals.begin()->first << "," << intervals.begin()->second << "\n";
-if (verbose) cerr << "intervals.end()=" << intervals.end()->first << "," << intervals.end()->second << "\n";
     auto iter = std::lower_bound(intervals.begin(),intervals.end(),tmp_interval);
-if (verbose) cerr << "get_flank_boundary_left_impl> 1.4 \n";
     size_t p = iter-intervals.begin();
-if (verbose) cerr << "get_flank_boundary_left_impl> 2  p=" << p << "\n";
     if (p<N_INTERVALS && intersect(tmp_interval,intervals.at(p))) {
-if (verbose) cerr << "get_flank_boundary_left_impl> 3 \n";
         tmp_interval.second=intervals.at(p).first;
         tmp_interval.first=tmp_interval.second>=flank_length?tmp_interval.second-flank_length:0;
     }
     if (p>0) {
-if (verbose) cerr << "get_flank_boundary_left_impl> 4 \n";
         p--;
         while (intersect(tmp_interval,intervals.at(p))) {
-if (verbose) cerr << "get_flank_boundary_left_impl> 5  p=" << p << "\n";
             tmp_interval.second=intervals.at(p).first;
             tmp_interval.first=tmp_interval.second>=flank_length?tmp_interval.second-flank_length:0;
             if (p==0) break;
             else p--;
         }
-if (verbose) cerr << "get_flank_boundary_left_impl> 6 \n";
     }
-if (verbose) cerr << "get_flank_boundary_left_impl> 7 \n";
     return tmp_interval.second==0?INT32_MAX:tmp_interval.first;
 }
 
 
 void VariantGraph::get_tandem_intervals(nid_t node_id, int32_t node_length, bool is_reverse, int32_t offset, vector<interval_t>& out) {
     size_t i, from;
-bool verbose = false;
 
     const auto OUT_FIRST = out.size();
     const pair<string,int32_t> COORDINATE = node_to_chromosome.find(node_id)->second;
@@ -191,30 +167,22 @@ bool verbose = false;
     while (i<N_INTERVALS) {
         if (INTERVALS.at(i).first>=tmp_interval.second) break;
         out.emplace_back(max(tmp_interval.first,INTERVALS.at(i).first),min(tmp_interval.second,INTERVALS.at(i).second));
-if (verbose) cerr << "get_tandem_intervals of node> 1  emplaced back " << max(tmp_interval.first,INTERVALS.at(i).first) << ", " << min(tmp_interval.second,INTERVALS.at(i).second) << "\n";
         i++;
     }
     if (!is_reverse) {
-if (verbose) cerr << "get_tandem_intervals of node> 2.0  \n";
         for (i=OUT_FIRST; i<out.size(); i++) {
-if (verbose) cerr << "get_tandem_intervals of node> 2.1 \n";
             out.at(i).first=out.at(i).first-tmp_interval.first+offset;
             out.at(i).second=out.at(i).second-tmp_interval.first+offset;
-if (verbose) cerr << "get_tandem_intervals of node> 2.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
         }
     }
     else {
-if (verbose) cerr << "get_tandem_intervals of node> 3.0 \n";
         std::reverse(out.begin()+OUT_FIRST,out.end());
         for (i=OUT_FIRST; i<out.size(); i++) {
-if (verbose) cerr << "get_tandem_intervals of node> 3.1 \n";
             std::swap(out.at(i).first,out.at(i).second);
             out.at(i).first=(tmp_interval.second-1)-(out.at(i).first-1)+offset;
             out.at(i).second=(tmp_interval.second-1)-(out.at(i).second-1)+offset;
-if (verbose) cerr << "get_tandem_intervals of node> 3.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
         }
     }
-if (verbose) cerr << "get_tandem_intervals of node> 4 \n";
 }
 
 
@@ -223,32 +191,24 @@ void VariantGraph::get_tandem_intervals(const vector<nid_t>& node_ids, const vec
     size_t i, j;
     int32_t offset, length, length_prime;
     nid_t node_id;
-bool verbose = false;
 
     // Collecting per-node tandem intervals, including entire non-ref nodes.
     out.clear(); offset=0; i=0;
     while (i<LENGTH) {
-if (verbose) cerr << "get_tandem_intervals> 1  i=" << i << " LENGTH=" << LENGTH << "\n";
         node_id=node_ids.at(i);
         length=node_lengths.at(i);
         if (is_reference_node(node_id)) {
-if (verbose) cerr << "get_tandem_intervals> 2 \n";
             get_tandem_intervals(node_id,length,is_reverse.at(i),offset,out);
             offset+=length;
             i++;
-if (verbose) cerr << "get_tandem_intervals> 3  i=" << i<< "\n";
         }
         else {
-if (verbose) cerr << "get_tandem_intervals> 4 \n";
             if (!out.empty() && out.at(out.size()-1).second==offset) {
-if (verbose) cerr << "get_tandem_intervals> 5 \n";
                 out.at(out.size()-1).second=offset+length;
                 offset+=length;
                 i++;
-if (verbose) cerr << "get_tandem_intervals> 6 \n";
             }
             else if (i<LENGTH-1) {
-if (verbose) cerr << "get_tandem_intervals> 7 \n";
                 j=out.size();
                 i++;
                 node_id=node_ids.at(i);
@@ -258,7 +218,6 @@ if (verbose) cerr << "get_tandem_intervals> 7 \n";
                 if (out.size()>j && out.at(j).first==offset+length) out.at(j).first=offset;
                 offset+=length+length_prime;
                 i++;
-if (verbose) cerr << "get_tandem_intervals> 8  i=" << i << "\n";
             }
             else {
                 offset+=length;
@@ -292,9 +251,7 @@ void VariantGraph::vcf_record_to_path_intervals(const vector<pair<string,bool>>&
     int32_t length, path_length_bps;
     nid_t id;
     handle_t handle1, handle2;
-bool verbose = false;
 
-if (verbose) cerr << "vcf_record_to_path_intervals> 1 \n";
     node_ids_buffer.clear(); is_reverse_buffer.clear(); node_lengths_buffer.clear(); tmp_edges.clear();
     id=stoll(path.at(0).first);
     rev=path.at(0).second;
@@ -316,13 +273,9 @@ if (verbose) cerr << "vcf_record_to_path_intervals> 1 \n";
         tmp_edges.emplace_back(graph.edge_handle(handle1,handle2));  // Canonized
         handle1=handle2;
     }
-if (verbose) cerr << "vcf_record_to_path_intervals> 2 \n";
     get_tandem_intervals(node_ids_buffer,is_reverse_buffer,node_lengths_buffer,intervals_buffer);
-if (verbose) cerr << "vcf_record_to_path_intervals> 3  tandem intervals: \n";
-if (verbose) for (i=0; i<intervals_buffer.size(); i++) cerr << intervals_buffer.at(i).first << ".." << intervals_buffer.at(i).second << "\n";
     out.clear(); x=0;
     for (i=0; i<PATH_LENGTH-1; i++) {
-if (verbose) cerr << "vcf_record_to_path_intervals> 4 \n";
         x+=node_lengths_buffer.at(i);
         found=false;
         if (tmp_edges.at(i)==edges_of_the_record.at(0)) {
@@ -335,7 +288,6 @@ if (verbose) cerr << "vcf_record_to_path_intervals> 4 \n";
             }
             if (p==N_EDGES) found=true;
         }
-if (verbose) cerr << "vcf_record_to_path_intervals> 5 \n";
         if (!found && tmp_edges.at(i)==edges_of_the_record.at(N_EDGES-1)) {
             // Reverse match
             j=i; p=N_EDGES-2; y=x;
@@ -347,19 +299,12 @@ if (verbose) cerr << "vcf_record_to_path_intervals> 5 \n";
             if (p==-1) found=true;
         }
         if (found) {
-if (verbose) cerr << "vcf_record_to_path_intervals> 6  x=" << x << " y=" << y << " interval length=" << (y-x) << "  intervals_buffer.size()=" << intervals_buffer.size() << "\n";
-int32_t left = get_flank_boundary_left_impl(x,intervals_buffer,flank_length);
-if (left==INT32_MAX) left=0;
-if (verbose) cerr << "vcf_record_to_path_intervals> 7  left=";
-if (verbose) cerr << left << "\n";
-int32_t right = get_flank_boundary_right_impl(y,path_length_bps,intervals_buffer,flank_length);
-if (right==INT32_MAX) right=path_length_bps-1;
-if (verbose) cerr << "vcf_record_to_path_intervals> 8  right=";
-if (verbose) cerr << right << "\n";
-if (verbose) cerr << "new interval length=" << (right-left) << "\n";
+            int32_t left = get_flank_boundary_left_impl(x,intervals_buffer,flank_length);
+            if (left==INT32_MAX) left=0;
+            int32_t right = get_flank_boundary_right_impl(y,path_length_bps,intervals_buffer,flank_length);
+            if (right==INT32_MAX) right=path_length_bps-1;
             out.emplace_back(left,right);
         }
-if (verbose) cerr << "vcf_record_to_path_intervals> 7 \n";
     }
 }
 
@@ -727,19 +672,11 @@ void VariantGraph::build(const string& chromosome, int32_t p, int32_t q, int32_t
 
 
 bool VariantGraph::would_graph_be_nontrivial(vector<VcfRecord>& records) {
-bool verbose = false;
-if (verbose) cerr << "would_graph_be_nontrivial> 1 \n";
-    if (records.size()==0) return false;
+    if (records.empty()) return false;
     pair<int32_t,int32_t> tmp_pair;
     for (auto& record: records) {
-if (verbose) cerr << "would_graph_be_nontrivial> 2 \n";
         record.get_reference_coordinates(false,tmp_pair);
-if (verbose) cerr << "would_graph_be_nontrivial> 3 \n";
         if (tmp_pair.first==INT32_MAX || tmp_pair.second==INT32_MAX) continue;
-if (verbose) cerr << "would_graph_be_nontrivial> 4 \n";
-if (verbose) cerr << "would_graph_be_nontrivial> record.is_symbolic: " << record.is_symbolic << "\n";
-if (verbose) cerr << "would_graph_be_nontrivial> record.is_breakend_single: " << to_string(record.is_breakend_single()) << "\n";
-if (verbose) cerr << "would_graph_be_nontrivial> record.is_breakend_virtual: " << record.is_breakend_virtual(chromosomes) << "\n";
         if ( (record.sv_type==VcfReader::TYPE_INSERTION && !record.is_symbolic) ||
              record.sv_type==VcfReader::TYPE_DELETION ||
              record.sv_type==VcfReader::TYPE_INVERSION ||
@@ -747,13 +684,8 @@ if (verbose) cerr << "would_graph_be_nontrivial> record.is_breakend_virtual: " <
              record.sv_type==VcfReader::TYPE_REPLACEMENT ||
              record.sv_type==VcfReader::TYPE_CNV ||
              (record.sv_type==VcfReader::TYPE_BREAKEND && record.is_breakend_single()>=1 && !record.is_breakend_virtual(chromosomes))
-             ) {
-if (verbose) cerr << "would_graph_be_nontrivial> 5 \n";
-            return true;
-        }
-if (verbose) cerr << "would_graph_be_nontrivial> 6 \n";
+             ) return true;
     }
-if (verbose) cerr << "would_graph_be_nontrivial> 7 \n";
     return false;
 }
 

--- a/src/VariantGraph.cpp
+++ b/src/VariantGraph.cpp
@@ -94,20 +94,27 @@ int32_t VariantGraph::get_flank_boundary_right(const string& chromosome_id, int3
 
 
 int32_t VariantGraph::get_flank_boundary_right_impl(int32_t pos, int32_t sequence_length, const vector<interval_t>& intervals, int32_t flank_length) {
+cerr << "get_flank_boundary_right_impl> 1 \n";
     const size_t N_INTERVALS = intervals.size();
+cerr << "get_flank_boundary_right_impl> 2  N_INTERVALS=" << N_INTERVALS << " \n";
     if (N_INTERVALS==0) return min(pos+flank_length-1,sequence_length-1);
     tmp_interval.first=pos; tmp_interval.second=pos+flank_length;
+cerr << "get_flank_boundary_right_impl> 3  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     auto iter = std::lower_bound(intervals.begin(),intervals.end(),tmp_interval);
     size_t p = iter-intervals.begin();
+cerr << "get_flank_boundary_right_impl> 4  p=" << p << "\n";
     if (p>0 && intersect(tmp_interval,intervals.at(p-1))) {
         tmp_interval.first=intervals.at(p-1).second;
         tmp_interval.second=tmp_interval.first+flank_length;
+cerr << "get_flank_boundary_right_impl> 5  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     }
     while (p<N_INTERVALS && intersect(tmp_interval,intervals.at(p))) {
         tmp_interval.first=intervals.at(p).second;
         tmp_interval.second=tmp_interval.first+flank_length;
+cerr << "get_flank_boundary_right_impl> 6  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
         p++;
     }
+cerr << "get_flank_boundary_right_impl> 7  tmp_interval.first=" << tmp_interval.first << " tmp_interval.second=" << tmp_interval.second << "\n";
     return tmp_interval.first>=sequence_length?INT32_MAX:min(tmp_interval.second-1,sequence_length-1);
 }
 
@@ -121,24 +128,38 @@ int32_t VariantGraph::get_flank_boundary_left(const string& chromosome_id, int32
 
 
 int32_t VariantGraph::get_flank_boundary_left_impl(int32_t pos, const vector<interval_t>& intervals, int32_t flank_length) {
+cerr << "get_flank_boundary_left_impl> 1 \n";
     const size_t N_INTERVALS = intervals.size();
+cerr << "get_flank_boundary_left_impl> 1.1 \n";
     if (N_INTERVALS==0) return pos>=flank_length?pos-flank_length:0;
+cerr << "get_flank_boundary_left_impl> 1.2 \n";
     tmp_interval.first=pos>=flank_length?pos-flank_length:0; tmp_interval.second=pos;
+cerr << "get_flank_boundary_left_impl> 1.3  N_INTERVALS=" << N_INTERVALS << "\n";
+cerr << "intervals.at(0)=" << intervals.at(0).first << "," << intervals.at(0).second << "\n";
+cerr << "intervals.begin()=" << intervals.begin()->first << "," << intervals.begin()->second << "\n";
+cerr << "intervals.end()=" << intervals.end()->first << "," << intervals.end()->second << "\n";
     auto iter = std::lower_bound(intervals.begin(),intervals.end(),tmp_interval);
+cerr << "get_flank_boundary_left_impl> 1.4 \n";
     size_t p = iter-intervals.begin();
+cerr << "get_flank_boundary_left_impl> 2  p=" << p << "\n";
     if (p<N_INTERVALS && intersect(tmp_interval,intervals.at(p))) {
+cerr << "get_flank_boundary_left_impl> 3 \n";
         tmp_interval.second=intervals.at(p).first;
         tmp_interval.first=tmp_interval.second>=flank_length?tmp_interval.second-flank_length:0;
     }
     if (p>0) {
+cerr << "get_flank_boundary_left_impl> 4 \n";
         p--;
         while (intersect(tmp_interval,intervals.at(p))) {
+cerr << "get_flank_boundary_left_impl> 5  p=" << p << "\n";
             tmp_interval.second=intervals.at(p).first;
             tmp_interval.first=tmp_interval.second>=flank_length?tmp_interval.second-flank_length:0;
             if (p==0) break;
             else p--;
         }
+cerr << "get_flank_boundary_left_impl> 6 \n";
     }
+cerr << "get_flank_boundary_left_impl> 7 \n";
     return tmp_interval.second==0?INT32_MAX:tmp_interval.first;
 }
 
@@ -146,7 +167,7 @@ int32_t VariantGraph::get_flank_boundary_left_impl(int32_t pos, const vector<int
 void VariantGraph::get_tandem_intervals(nid_t node_id, int32_t node_length, bool is_reverse, int32_t offset, vector<interval_t>& out) {
     size_t i, from;
 
-    const auto OUT_FIRST = out.end();
+    const auto OUT_FIRST = out.size();
     const pair<string,int32_t> COORDINATE = node_to_chromosome.find(node_id)->second;
     const string CHROMOSOME_ID = COORDINATE.first;
     if (!tandem_track.contains(CHROMOSOME_ID)) return;
@@ -167,22 +188,30 @@ void VariantGraph::get_tandem_intervals(nid_t node_id, int32_t node_length, bool
     while (i<N_INTERVALS) {
         if (INTERVALS.at(i).first>=tmp_interval.second) break;
         out.emplace_back(max(tmp_interval.first,INTERVALS.at(i).first),min(tmp_interval.second,INTERVALS.at(i).second));
+cerr << "get_tandem_intervals of node> 1  emplaced back " << max(tmp_interval.first,INTERVALS.at(i).first) << ", " << min(tmp_interval.second,INTERVALS.at(i).second) << "\n";
         i++;
     }
     if (!is_reverse) {
-        for (i=OUT_FIRST-out.begin(); i<out.size(); i++) {
+cerr << "get_tandem_intervals of node> 2.0  \n";
+        for (i=OUT_FIRST; i<out.size(); i++) {
+cerr << "get_tandem_intervals of node> 2.1 \n";
             out.at(i).first=out.at(i).first-tmp_interval.first+offset;
             out.at(i).second=out.at(i).second-tmp_interval.first+offset;
+cerr << "get_tandem_intervals of node> 2.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
         }
     }
     else {
-        std::reverse(OUT_FIRST,out.end());
-        for (i=OUT_FIRST-out.begin(); i<out.size(); i++) {
+cerr << "get_tandem_intervals of node> 3.0 \n";
+        std::reverse(out.begin()+OUT_FIRST,out.end());
+        for (i=OUT_FIRST; i<out.size(); i++) {
+cerr << "get_tandem_intervals of node> 3.1 \n";
             std::swap(out.at(i).first,out.at(i).second);
             out.at(i).first=(tmp_interval.second-1)-(out.at(i).first-1)+offset;
             out.at(i).second=(tmp_interval.second-1)-(out.at(i).second-1)+offset;
+cerr << "get_tandem_intervals of node> 3.2  reset interval to " << out.at(i).first << ", " << out.at(i).second << "\n";
         }
     }
+cerr << "get_tandem_intervals of node> 4 \n";
 }
 
 
@@ -195,33 +224,49 @@ void VariantGraph::get_tandem_intervals(const vector<nid_t>& node_ids, const vec
     // Collecting per-node tandem intervals, including entire non-ref nodes.
     out.clear(); offset=0; i=0;
     while (i<LENGTH) {
+cerr << "get_tandem_intervals> 1  i=" << i << " LENGTH=" << LENGTH << "\n";
         node_id=node_ids.at(i);
         length=node_lengths.at(i);
         if (is_reference_node(node_id)) {
+cerr << "get_tandem_intervals> 2 \n";
             get_tandem_intervals(node_id,length,is_reverse.at(i),offset,out);
             offset+=length;
+            i++;
+cerr << "get_tandem_intervals> 3  i=" << i<< "\n";
         }
         else {
+cerr << "get_tandem_intervals> 4 \n";
             if (!out.empty() && out.at(out.size()-1).second==offset) {
+cerr << "get_tandem_intervals> 5 \n";
                 out.at(out.size()-1).second=offset+length;
                 offset+=length;
+                i++;
+cerr << "get_tandem_intervals> 6 \n";
             }
             else if (i<LENGTH-1) {
-                auto iter = out.end();
+cerr << "get_tandem_intervals> 7 \n";
+                j=out.size();
                 i++;
                 node_id=node_ids.at(i);
                 length_prime=node_lengths.at(i);
                 if (!is_reference_node(node_id)) throw runtime_error("ERROR: the path contains a non-ref node adjacent to another non-ref node?!");
                 get_tandem_intervals(node_id,length_prime,is_reverse.at(i),offset+length,out);
-                if (out.end()!=iter && out.at(iter-out.begin()).first==offset+length) out.at(iter-out.begin()).first=offset;
+                if (out.size()>j && out.at(j).first==offset+length) out.at(j).first=offset;
                 offset+=length+length_prime;
+                i++;
+cerr << "get_tandem_intervals> 8  i=" << i << "\n";
+            }
+            else {
+                offset+=length;
+                i++;
             }
         }
     }
+    if (out.empty()) return;
 
     // Compacting adjacent intervals
     j=0;
-    for (i=1; i<LENGTH; i++) {
+    for (i=1; i<out.size(); i++) {
         if (out.at(i).first==out.at(j).second) out.at(j).second=out.at(i).second;
         else std::swap(out.at(++j),out.at(i));
     }
@@ -235,15 +280,16 @@ void VariantGraph::get_tandem_intervals(const vector<nid_t>& node_ids, const vec
  * intervals_buffer`.
  */
 void VariantGraph::vcf_record_to_path_intervals(const vector<pair<string,bool>>& path, const vector<edge_t>& edges_of_the_record, int32_t flank_length, vector<interval_t>& out) {
-    const size_t PATH_LENGTH = path.size();
+    const auto PATH_LENGTH = (int32_t)path.size();
     if (PATH_LENGTH<2) { out.clear(); return; }
-    const size_t N_EDGES = edges_of_the_record.size();
+    const auto N_EDGES = (int32_t)edges_of_the_record.size();
     bool found, rev;
     int32_t i, j, p, x, y;
     int32_t length, path_length_bps;
     nid_t id;
     handle_t handle1, handle2;
 
+cerr << "vcf_record_to_path_intervals> 1 \n";
     node_ids_buffer.clear(); is_reverse_buffer.clear(); node_lengths_buffer.clear(); tmp_edges.clear();
     id=stoll(path.at(0).first);
     rev=path.at(0).second;
@@ -265,32 +311,50 @@ void VariantGraph::vcf_record_to_path_intervals(const vector<pair<string,bool>>&
         tmp_edges.emplace_back(graph.edge_handle(handle1,handle2));  // Canonized
         handle1=handle2;
     }
+cerr << "vcf_record_to_path_intervals> 2 \n";
     get_tandem_intervals(node_ids_buffer,is_reverse_buffer,node_lengths_buffer,intervals_buffer);
+cerr << "vcf_record_to_path_intervals> 3  tandem intervals: \n";
+for (i=0; i<intervals_buffer.size(); i++) cerr << intervals_buffer.at(i).first << ".." << intervals_buffer.at(i).second << "\n";
     out.clear(); x=0;
-    for (i=0; i<tmp_edges.size(); i++) {
+    for (i=0; i<PATH_LENGTH-1; i++) {
+cerr << "vcf_record_to_path_intervals> 4 \n";
         x+=node_lengths_buffer.at(i);
         found=false;
         if (tmp_edges.at(i)==edges_of_the_record.at(0)) {
             // Forward match
             j=i; p=1; y=x;
-            while (j<tmp_edges.size()-1 && p<N_EDGES) {
+            while (j<(PATH_LENGTH-1)-1 && p<N_EDGES) {
                 j++;
                 y+=node_lengths_buffer.at(j);
                 if (tmp_edges.at(j)==edges_of_the_record.at(p)) p++;
             }
             if (p==N_EDGES) found=true;
         }
+cerr << "vcf_record_to_path_intervals> 5 \n";
         if (!found && tmp_edges.at(i)==edges_of_the_record.at(N_EDGES-1)) {
             // Reverse match
             j=i; p=N_EDGES-2; y=x;
-            while (j<tmp_edges.size()-1 && p>=0) {
+            while (j<(PATH_LENGTH-1)-1 && p>=0) {
                 j++;
                 y+=node_lengths_buffer.at(j);
                 if (tmp_edges.at(j)==edges_of_the_record.at(p)) p--;
             }
             if (p==-1) found=true;
         }
-        if (found) out.emplace_back(get_flank_boundary_left_impl(x,intervals_buffer,flank_length),get_flank_boundary_right_impl(y,path_length_bps,intervals_buffer,flank_length));
+        if (found) {
+cerr << "vcf_record_to_path_intervals> 6  x=" << x << " y=" << y << " interval length=" << (y-x) << "  intervals_buffer.size()=" << intervals_buffer.size() << "\n";
+int32_t left = get_flank_boundary_left_impl(x,intervals_buffer,flank_length);
+if (left==INT32_MAX) left=0;
+cerr << "vcf_record_to_path_intervals> 7  left=";
+cerr << left << "\n";
+int32_t right = get_flank_boundary_right_impl(y,path_length_bps,intervals_buffer,flank_length);
+if (right==INT32_MAX) right=path_length_bps-1;
+cerr << "vcf_record_to_path_intervals> 8  right=";
+cerr << right << "\n";
+cerr << "new interval length=" << (right-left) << "\n";
+            out.emplace_back(left,right);
+        }
+cerr << "vcf_record_to_path_intervals> 7 \n";
     }
 }
 
@@ -658,11 +722,18 @@ void VariantGraph::build(const string& chromosome, int32_t p, int32_t q, int32_t
 
 
 bool VariantGraph::would_graph_be_nontrivial(vector<VcfRecord>& records) {
+cerr << "would_graph_be_nontrivial> 1 \n";
     if (records.size()==0) return false;
     pair<int32_t,int32_t> tmp_pair;
     for (auto& record: records) {
+cerr << "would_graph_be_nontrivial> 2 \n";
         record.get_reference_coordinates(false,tmp_pair);
+cerr << "would_graph_be_nontrivial> 3 \n";
         if (tmp_pair.first==INT32_MAX || tmp_pair.second==INT32_MAX) continue;
+cerr << "would_graph_be_nontrivial> 4 \n";
+cerr << "would_graph_be_nontrivial> record.is_symbolic: " << record.is_symbolic << "\n";
+cerr << "would_graph_be_nontrivial> record.is_breakend_single: " << to_string(record.is_breakend_single()) << "\n";
+cerr << "would_graph_be_nontrivial> record.is_breakend_virtual: " << record.is_breakend_virtual(chromosomes) << "\n";
         if ( (record.sv_type==VcfReader::TYPE_INSERTION && !record.is_symbolic) ||
              record.sv_type==VcfReader::TYPE_DELETION ||
              record.sv_type==VcfReader::TYPE_INVERSION ||
@@ -670,8 +741,13 @@ bool VariantGraph::would_graph_be_nontrivial(vector<VcfRecord>& records) {
              record.sv_type==VcfReader::TYPE_REPLACEMENT ||
              record.sv_type==VcfReader::TYPE_CNV ||
              (record.sv_type==VcfReader::TYPE_BREAKEND && record.is_breakend_single()>=1 && !record.is_breakend_virtual(chromosomes))
-             ) return true;
+             ) {
+cerr << "would_graph_be_nontrivial> 5 \n";
+            return true;
+        }
+cerr << "would_graph_be_nontrivial> 6 \n";
     }
+cerr << "would_graph_be_nontrivial> 7 \n";
     return false;
 }
 

--- a/src/VariantGraph.cpp
+++ b/src/VariantGraph.cpp
@@ -350,7 +350,9 @@ void VariantGraph::build(vector<VcfRecord>& records, int32_t flank_length, int32
         record.get_reference_coordinates(false,tmp_pair);
         if (tmp_pair.first==INT32_MAX || tmp_pair.second==INT32_MAX) continue;
         if (tmp_pair.first!=tmp_pair.second) {
-            first_positions.push_back(tmp_pair.first); first_positions.push_back(tmp_pair.second);
+            first_positions.push_back(tmp_pair.first);
+            if (tmp_pair.second>main_chromosome_length) tmp_pair.second=main_chromosome_length;
+            first_positions.push_back(tmp_pair.second);
             if (record.sv_type==VcfReader::TYPE_REPLACEMENT) {
                 const handle_t handle_alt = graph.create_handle(record.alt.substr(1));
                 insertion_handles.emplace_back(handle_alt);

--- a/src/VcfReader.cpp
+++ b/src/VcfReader.cpp
@@ -28,6 +28,8 @@ const char VcfReader::GT_SEPARATOR = ':';
 const char VcfReader::BREAKEND_SEPARATOR = ':';
 const char VcfReader::UNPHASED_CHAR = '/';
 const char VcfReader::PHASED_CHAR = '|';
+const string VcfReader::CHR_STR_LOWER = "chr";
+const string VcfReader::CHR_STR_UPPER = "CHR";
 
 const char VcfReader::INFO_ASSIGNMENT = '=';
 const char VcfReader::INFO_SEPARATOR = ';';
@@ -525,7 +527,9 @@ bool VcfRecord::is_alt_symbolic() const { return alt.at(0)==VcfReader::SYMBOLIC_
 
 
 uint8_t VcfRecord::is_breakend_single() const {
-    if (alt.at(0)==VcfReader::VCF_MISSING_CHAR || alt.at(alt.length()-1)==VcfReader::VCF_MISSING_CHAR) {
+    const char first = alt.at(0);
+    const char last = alt.at(alt.length()-1);
+    if (first==VcfReader::VCF_MISSING_CHAR || last==VcfReader::VCF_MISSING_CHAR) {
         const uint32_t length = alt.length();
         if (length==2) return 0;
         else if (length>2) return 1;
@@ -535,12 +539,18 @@ uint8_t VcfRecord::is_breakend_single() const {
 
 
 bool VcfRecord::is_breakend_virtual(const unordered_map<string,string>& chromosomes) {
+cerr << "is_breakend_virtual> 1 \n";
     if (is_symbolic) return false;
+cerr << "is_breakend_virtual> 2 \n";
     if (pos==0 || pos==chromosomes.at(chrom).length()+1) return true;
+cerr << "is_breakend_virtual> 3 \n";
     const int32_t p = get_breakend_pos();
+cerr << "is_breakend_virtual> 4 \n";
     if (p==INT32_MAX) return false;
+cerr << "is_breakend_virtual> 5 \n";
     string chr_trans;
     get_breakend_chromosome(chr_trans);
+cerr << "is_breakend_virtual> 6 \n";
     return (p==0 || p==chromosomes.at(chr_trans).length()+1);
 }
 
@@ -558,6 +568,7 @@ void VcfRecord::get_breakend_chromosome(string& out) const {
         else if (c==VcfReader::BREAKEND_SEPARATOR) break;
         else if (p!=UINT16_MAX) out.push_back(c);
     }
+    if (out.starts_with(VcfReader::CHR_STR_UPPER)) out.replace(0,VcfReader::CHR_STR_LOWER.length(),VcfReader::CHR_STR_LOWER);
 }
 
 

--- a/src/VcfReader.cpp
+++ b/src/VcfReader.cpp
@@ -18,6 +18,7 @@ const uint8_t VcfReader::N_NONSAMPLE_FIELDS_VCF = 9;
 const char VcfReader::LINE_END = '\n';
 const char VcfReader::VCF_SEPARATOR = '\t';
 const char VcfReader::VCF_MISSING_CHAR = '.';
+const string VcfReader::VCF_MISSING_STRING = ".";
 const char VcfReader::SYMBOLIC_CHAR_OPEN = '<';
 const char VcfReader::SYMBOLIC_CHAR_CLOSE = '>';
 const char VcfReader::BREAKEND_CHAR_OPEN = '[';
@@ -366,7 +367,7 @@ void VcfRecord::set_sv_length(string& tmp_buffer) {
 
 void VcfRecord::print(ostream& stream) const {
     stream << chrom << VcfReader::VCF_SEPARATOR << pos << VcfReader::VCF_SEPARATOR << id << VcfReader::VCF_SEPARATOR << ref << VcfReader::VCF_SEPARATOR << alt << VcfReader::VCF_SEPARATOR;
-    if (qual==-1) stream << '.';
+    if (qual==-1) stream << VcfReader::VCF_MISSING_CHAR;
     else stream << qual;
     stream << VcfReader::VCF_SEPARATOR << filter << VcfReader::VCF_SEPARATOR << info << VcfReader::VCF_SEPARATOR << format;
 

--- a/src/VcfReader.cpp
+++ b/src/VcfReader.cpp
@@ -539,18 +539,19 @@ uint8_t VcfRecord::is_breakend_single() const {
 
 
 bool VcfRecord::is_breakend_virtual(const unordered_map<string,string>& chromosomes) {
-cerr << "is_breakend_virtual> 1 \n";
+bool verbose = false;
+if (verbose) cerr << "is_breakend_virtual> 1 \n";
     if (is_symbolic) return false;
-cerr << "is_breakend_virtual> 2 \n";
+if (verbose) cerr << "is_breakend_virtual> 2 \n";
     if (pos==0 || pos==chromosomes.at(chrom).length()+1) return true;
-cerr << "is_breakend_virtual> 3 \n";
+if (verbose) cerr << "is_breakend_virtual> 3 \n";
     const int32_t p = get_breakend_pos();
-cerr << "is_breakend_virtual> 4 \n";
+if (verbose) cerr << "is_breakend_virtual> 4 \n";
     if (p==INT32_MAX) return false;
-cerr << "is_breakend_virtual> 5 \n";
+if (verbose) cerr << "is_breakend_virtual> 5 \n";
     string chr_trans;
     get_breakend_chromosome(chr_trans);
-cerr << "is_breakend_virtual> 6 \n";
+if (verbose) cerr << "is_breakend_virtual> 6 \n";
     return (p==0 || p==chromosomes.at(chr_trans).length()+1);
 }
 

--- a/src/executable/annotate.cpp
+++ b/src/executable/annotate.cpp
@@ -562,11 +562,11 @@ void compute_graph_evaluation(
 
     cerr << "Reading VCF... " << '\n';
     vcf_reader.for_record_in_vcf([&](VcfRecord& r){
-        // TODO: allow breakends in evaluation
-        if (r.sv_type == VcfReader::TYPE_BREAKEND){
-            cerr << "WARNING: skipping breakend"  << '\n';
-            return;
-        }
+//        // TODO: allow breakends in evaluation
+//        if (r.sv_type == VcfReader::TYPE_BREAKEND){
+//            cerr << "WARNING: skipping breakend"  << '\n';
+//            return;
+//        }
 
         r.get_reference_coordinates(false, record_coord);
 

--- a/src/executable/annotate.cpp
+++ b/src/executable/annotate.cpp
@@ -750,7 +750,9 @@ void annotate(
                 region_transmaps,
                 false,
                 force_unique_reads,
-                false
+                false,
+                false,
+                flank_length
         );
     }
     else{
@@ -767,7 +769,8 @@ void annotate(
                 false,
                 false,
                 force_unique_reads,
-                false
+                false,
+                flank_length
         );
     }
 

--- a/src/executable/annotate.cpp
+++ b/src/executable/annotate.cpp
@@ -252,38 +252,39 @@ void compute_graph_evaluation_thread_fn(
     vcf_reader.get_file_path(vcf);
     string vcf_name_prefix = get_vcf_name_prefix(vcf);
     string buffer;
+bool verbose = false;
 
     while (i < regions.size()){
         const auto& region = regions.at(i);
-cerr << "ANNOTATE> 0  region=" << region.name << ":" << region.start << ".." << region.stop << "\n";
+if (verbose) cerr << "ANNOTATE> 0  region=" << region.name << ":" << region.start << ".." << region.stop << "\n";
 
         path subdir = output_dir / region.to_unflanked_string('_', flank_length);
-cerr << "ANNOTATE> 0.1  region_records contains the region? " << region_records.contains(region) << "\n";
+if (verbose) cerr << "ANNOTATE> 0.1  region_records contains the region? " << region_records.contains(region) << "\n";
 
         auto records = region_records.at(region);
-cerr << "ANNOTATE> 0.2\n";
+if (verbose) cerr << "ANNOTATE> 0.2\n";
 
         create_directories(subdir);
-cerr << "ANNOTATE> 0.3\n";
+if (verbose) cerr << "ANNOTATE> 0.3\n";
 
         path gfa_path = subdir / "graph.gfa";
         path fasta_filename = subdir / "haplotypes.fasta";
-cerr << "ANNOTATE> 0.4\n";
+if (verbose) cerr << "ANNOTATE> 0.4\n";
 
         VariantGraph variant_graph(ref_sequences, contig_tandems);
-cerr << "ANNOTATE> 0.5\n";
+if (verbose) cerr << "ANNOTATE> 0.5\n";
 
         // Check if the region actually contains any usable variants, and use corresponding build() functions
         if (variant_graph.would_graph_be_nontrivial(records)){
-cerr << "ANNOTATE> 0.6\n";
+if (verbose) cerr << "ANNOTATE> 0.6\n";
             variant_graph.build(records, int32_t(flank_length), numeric_limits<int32_t>::max(), region.start + flank_length, region.stop - flank_length, false);
-cerr << "ANNOTATE> 0.7\n";
+if (verbose) cerr << "ANNOTATE> 0.7\n";
         }
         else{
             // VariantGraph assumes that the flank length needs to be added to the region
-cerr << "ANNOTATE> 0.8\n";
+if (verbose) cerr << "ANNOTATE> 0.8\n";
             variant_graph.build(region.name, region.start + flank_length, region.stop - flank_length, flank_length);
-cerr << "ANNOTATE> 0.9\n";
+if (verbose) cerr << "ANNOTATE> 0.9\n";
         }
 
         cerr << "WRITING GFA to file: " << gfa_path << '\n';
@@ -326,30 +327,45 @@ cerr << "ANNOTATE> 0.9\n";
 
         vector<VariantSupport> variant_supports(variant_graph.vcf_records.size());
         vector<float> max_observed_identities(variant_graph.vcf_records.size());
-cerr << "ANNOTATE> 1 \n";
+if (verbose) cerr << "ANNOTATE> 1 \n";
         // First annotate all the variants as tandem or not
         int32_t bnd_pos;
         string bnd_chromosome;
         for (size_t v=0; v<variant_supports.size(); v++){
+if (verbose) cerr << "ANNOTATE> 1.1 \n";
             auto& record = variant_graph.vcf_records[v];
+if (verbose) cerr << "ANNOTATE> 1.2 \n";
             coord_t ref_coord;
             record.get_reference_coordinates(false, ref_coord);
+if (verbose) cerr << "ANNOTATE> 1.3 \n";
             bool is_tandem = false;
-            contig_interval_trees.at(region.name).overlap_find_all({ref_coord.first, ref_coord.second}, [&](auto iter) {
-                is_tandem=true;
-                return false;
-            });
-            if (!is_tandem && record.sv_type==VcfReader::TYPE_BREAKEND && record.is_breakend_single()==2) {
-                record.get_breakend_chromosome(bnd_chromosome);
-                bnd_pos=record.get_breakend_pos();
-                contig_interval_trees.at(bnd_chromosome).overlap_find_all({bnd_pos,bnd_pos}, [&](auto iter) {
+            if (contig_interval_trees.contains(region.name)) {
+                contig_interval_trees.at(region.name).overlap_find_all({ref_coord.first, ref_coord.second}, [&](auto iter) {
+if (verbose) cerr << "ANNOTATE> 1.4 \n";
                     is_tandem=true;
                     return false;
                 });
             }
+if (verbose) cerr << "ANNOTATE> 1.5 \n";
+            if (!is_tandem && record.sv_type==VcfReader::TYPE_BREAKEND && record.is_breakend_single()==2) {
+if (verbose) cerr << "ANNOTATE> 1.6 \n";
+                record.get_breakend_chromosome(bnd_chromosome);
+if (verbose) cerr << "ANNOTATE> 1.7 \n";
+                bnd_pos=record.get_breakend_pos();
+if (verbose) cerr << "ANNOTATE> 1.8 \n";
+                if (contig_interval_trees.contains(bnd_chromosome)) {
+                    contig_interval_trees.at(bnd_chromosome).overlap_find_all({bnd_pos,bnd_pos}, [&](auto iter) {
+if (verbose) cerr << "ANNOTATE> 1.9 \n";
+                        is_tandem=true;
+                        return false;
+                    });
+                }
+            }
+if (verbose) cerr << "ANNOTATE> 1.10 \n";
             variant_supports[v].is_tandem = is_tandem;
+if (verbose) cerr << "ANNOTATE> 1.11 \n";
         }
-cerr << "ANNOTATE> 2 \n";
+if (verbose) cerr << "ANNOTATE> 2 \n";
 
         // Iterate the alignments and accumulate their stats w.r.t. variants.
         // For tandem-contained variants, stats pertain to entire tandem.
@@ -368,14 +384,14 @@ cerr << "ANNOTATE> 2 \n";
             vector<interval_t> ref_intervals, singleton_interval, no_interval;
             variant_graph.for_each_vcf_record(path, [&](size_t id, const vector<edge_t>& edges_of_the_record, const VcfRecord& _record){
                 auto record = _record;
-cerr << "ANNOTATE> 2.5  record: ";
-record.print(cerr);
-cerr << "\n";
+if (verbose) cerr << "ANNOTATE> 2.5  record: ";
+if (verbose) record.print(cerr);
+if (verbose) cerr << "\n";
                 variant_graph.vcf_record_to_path_intervals(path,edges_of_the_record,variant_flank_length,ref_intervals);
-cerr << "ANNOTATE> 2.6 \n";
+if (verbose) cerr << "ANNOTATE> 2.6 \n";
                 max_identity=0; max_length=0;
                 for (const auto& interval: ref_intervals) {
-cerr << "ANNOTATE> 2.7  " << interval.first << ".." << interval.second << "\n";
+if (verbose) cerr << "ANNOTATE> 2.7  " << interval.first << ".." << interval.second << "\n";
 if (interval.second-interval.first>500000) cerr << "WARNING: TOO LONG INTERVAL!!!! " << (interval.second-interval.first) << "\n";
                     AlignmentSummary summary;
                     singleton_interval.clear(); singleton_interval.push_back(interval);
@@ -394,7 +410,7 @@ if (interval.second-interval.first>500000) cerr << "WARNING: TOO LONG INTERVAL!!
                         placeholder.code = 7;   // '=' operation
                         summary.update(placeholder,true);
                     }
-cerr << "ANNOTATE> 2.8 \n";
+if (verbose) cerr << "ANNOTATE> 2.8 \n";
 
                     max_identity=max(max_identity,summary.compute_identity());
                     max_length=max(max_length,interval.second-interval.first);
@@ -405,19 +421,19 @@ cerr << "ANNOTATE> 2.8 \n";
 
                 // FC> Max or min or avg?
                 // Update the region length for this VCF record to the max length over all intervals (arbitrary).
-cerr << "variant_supports[" << id << "].length_of_evaluated_region before: " << variant_supports[id].length_of_evaluated_region << "\n";
+if (verbose) cerr << "variant_supports[" << id << "].length_of_evaluated_region before: " << variant_supports[id].length_of_evaluated_region << "\n";
                 if (variant_supports[id].length_of_evaluated_region==0 || is_spanning) {
                     variant_supports[id].length_of_evaluated_region=max(variant_supports[id].length_of_evaluated_region,max_length);
-cerr << "variant_supports[" << id << "].length_of_evaluated_region after: " << variant_supports[id].length_of_evaluated_region << "\n";
+if (verbose) cerr << "variant_supports[" << id << "].length_of_evaluated_region after: " << variant_supports[id].length_of_evaluated_region << "\n";
                 }
 
                 // FC> Max or min or avg?
                 // Update the histogram for this VCF record to the max identity over all intervals (arbitrary).
                 variant_supports[id].identity[is_spanning][path_is_reverse].emplace_back(max_identity);
-cerr << "ANNOTATE> 2.9 \n";
+if (verbose) cerr << "ANNOTATE> 2.9 \n";
             });
         });
-cerr << "ANNOTATE> 3 \n";
+if (verbose) cerr << "ANNOTATE> 3 \n";
         const double total_coverage = float(l_coverage+r_coverage)/2.0;
 
         path output_path = subdir / "annotated.vcf";
@@ -428,7 +444,7 @@ cerr << "ANNOTATE> 3 \n";
         out_file << "##INFO=<ID=" << label << "_NEIGHBORS,Number=1,Type=Float,Description=\"The number of variants that shared the window/region (including this one)\",Source=\"hapestry\",Version=\"0.0.0.0.0.1\">\n";
         vcf_reader.print_minimal_header(out_file);
         string s;
-cerr << "ANNOTATE> 4 \n";
+if (verbose) cerr << "ANNOTATE> 4 \n";
         for (size_t v=0; v<variant_supports.size(); v++){
             VcfRecord& record = variant_graph.vcf_records[v];
             variant_supports.at(v).get_support_string(s);
@@ -443,7 +459,7 @@ cerr << "ANNOTATE> 4 \n";
             record.info.append(",");
             record.info.append(to_string(variant_supports.at(v).length_of_evaluated_region));
 
-if (variant_supports.at(v).length_of_evaluated_region>500000) {
+if (verbose && variant_supports.at(v).length_of_evaluated_region>500000) {
     cerr << "length_of_evaluated_region=" << variant_supports.at(v).length_of_evaluated_region << "\n";
     std::exit(1);
 }
@@ -460,11 +476,11 @@ if (variant_supports.at(v).length_of_evaluated_region>500000) {
             record.print(out_file);
             out_file << '\n';
         }
-cerr << "ANNOTATE> 5 \n";
+if (verbose) cerr << "ANNOTATE> 5 \n";
 
         i = job_index.fetch_add(1);
     }
-cerr << "ANNOTATE> 6 \n";
+if (verbose) cerr << "ANNOTATE> 6 \n";
 }
 
 

--- a/src/executable/clean_bnds.cpp
+++ b/src/executable/clean_bnds.cpp
@@ -1,35 +1,18 @@
 #include "fasta.hpp"
-
-
-#include "windows.hpp"
-#include "Timer.hpp"
 #include "CLI11.hpp"
-#include "bed.hpp"
+#include "VcfReader.hpp"
 
 #include <unordered_map>
 #include <exception>
-#include <stdexcept>
 #include <iostream>
-#include <limits>
 
-using std::numeric_limits;
 using std::unordered_map;
-using std::runtime_error;
 using std::exception;
 using std::ifstream;
 using std::ofstream;
-using std::thread;
-using std::atomic;
-using std::mutex;
 using std::cerr;
-using std::min;
-using std::max;
-using std::cref;
-using std::ref;
-
 
 using namespace sv_merge;
-
 
 
 /**
@@ -49,14 +32,15 @@ void get_vcf_header(const path& input_vcf, string& header) {
         line.clear();
         c=(char)file.peek();
         if (c!=VcfReader::VCF_COMMENT) break;
-        line.push_back(c);
         while (file.get(c)) {
             if (c==VcfReader::LINE_END || c==EOF) break;
             else line.push_back(c);
         }
-        is_last_line=true;
-        for (i=0; i<VcfReader::VCF_HEADER_PREFIX_LENGTH; i++) {
-            if (toupper(line.at(i))!=VcfReader::VCF_HEADER_PREFIX.at(i)) { is_last_line=false; break; }
+        is_last_line=line.length()>=VcfReader::VCF_HEADER_PREFIX_LENGTH;
+        if (is_last_line) {
+            for (i=0; i<VcfReader::VCF_HEADER_PREFIX_LENGTH; i++) {
+                if (toupper(line.at(i))!=VcfReader::VCF_HEADER_PREFIX.at(i)) { is_last_line=false; break; }
+            }
         }
         if (is_last_line) header.append("##INFO=<ID=MATEID,Number=1,Type=String,Description=\"ID of mate breakends\">\n");
         header.append(line+"\n");
@@ -67,9 +51,9 @@ void get_vcf_header(const path& input_vcf, string& header) {
 
 /**
  * - Removes symbolic breakends and virtual telomeric breakends.
- * - Ensures that REF and ALT in BND records use the same first character, and that such a character is the same as
- *   in the ref.
- * - Ensures that every non-single BND record has a mate.
+ * - Ensures that REF and ALT in BND records have the same character at POS, and that such a character is the same as
+ *   in the ref (this may not be true in e.g. sniffles).
+ * - Ensures that every non-single BND record has a symmetrical mate record.
  * - Discards BND records whose ALT allele does not conform to the VCF spec (e.g. sniffles can output ACNNNNNNNNNNNNNNN
  *   in the ALT of a BND record).
  * - Transforms long non-BND calls into sets of BNDs.
@@ -79,7 +63,8 @@ void get_vcf_header(const path& input_vcf, string& header) {
 int main (int argc, char* argv[]) {
     bool has_mate;
     char c;
-    int32_t n_records, min_sv_length, single_breakend_length, pos2, length;
+    int32_t pos2, n_records, min_sv_length, single_breakend_length, chromosome_length;
+    size_t alt_length;
     string header, current_chromosome, chromosome2, buffer;
     path ref_fasta, input_vcf, output_vcf;
 
@@ -93,7 +78,7 @@ int main (int argc, char* argv[]) {
     app.add_option("--min_sv_length",min_sv_length,"Only calls this length or longer are transformed into BNDs. Every other call is kept intact and printed to the output.")->required();
     app.add_option("--single_breakend_length",single_breakend_length,"A long INS is converted to a pair of single breakends with this number of bases each.")->required();
     app.add_option("--output_vcf",output_vcf,"Path to output VCF file")->required();
-    CLI11_PARSE(app,argc,argv);
+    CLI11_PARSE(app,argc,argv)
     if (min_sv_length<(single_breakend_length<<1)) throw runtime_error("The following command-line arguments are inconsistent: min_sv_length="+std::to_string(min_sv_length)+" single_breakend_length="+std::to_string(single_breakend_length));
 
     cerr << "Loading the reference...\n";
@@ -104,7 +89,7 @@ int main (int argc, char* argv[]) {
     cerr << "Reading the VCF... " << '\n';
     VcfReader vcf_reader(input_vcf);
     vcf_reader.min_qual = numeric_limits<float>::min();
-    vcf_reader.min_sv_length = 1;
+    vcf_reader.min_sv_length = 0;
     vcf_reader.progress_n_lines = 100'000;
     ofstream outstream(output_vcf.string());
     if (!outstream.good() || !outstream.is_open()) throw runtime_error("ERROR: file could not be written: "+output_vcf.string());
@@ -113,58 +98,64 @@ int main (int argc, char* argv[]) {
     n_records=0;
     vcf_reader.for_record_in_vcf([&](VcfRecord& record) {
         n_records++;
-        if (n_records%100'000==0) cerr << "Processed " << std::to_string(n_records) << " records...\n";
         if (record.sv_type==-1) { record.print(outstream); outstream << "\n"; return; }
         else if (record.sv_type==VcfReader::TYPE_BREAKEND) {
             if (record.is_symbolic || !record.is_valid_bnd_alt() || record.is_breakend_virtual(ref_sequences)) return;
             has_mate=record.get_info_field(MATEID_STR,0,buffer)!=string::npos;
             // Fixing REF and ALT character at POS, if unknown.
-            if (toupper(record.ref.at(0))==VcfReader::UNKNOWN_BASE) record.ref.at(0)=ref_sequences.at(record.chrom).at(record.pos-1);
-            length=record.alt.length();
-            if (toupper(record.alt.at(0))==VcfReader::UNKNOWN_BASE) record.alt.at(0)=ref_sequences.at(record.chrom).at(record.pos-1);
-            if (toupper(record.alt.at(length-1))==VcfReader::UNKNOWN_BASE) record.alt.at(length-1)=ref_sequences.at(record.chrom).at(record.pos-1);
+            c=ref_sequences.at(record.chrom).at(record.pos-1);
+            if (toupper(record.ref.at(0))==VcfReader::UNKNOWN_BASE) record.ref.at(0)=c;
+            alt_length=record.alt.length();
+            if (toupper(record.alt.at(0))==VcfReader::UNKNOWN_BASE) record.alt.at(0)=c;
+            if (toupper(record.alt.at(alt_length-1))==VcfReader::UNKNOWN_BASE) record.alt.at(alt_length-1)=c;
             if (!record.is_breakend_single() && !has_mate) record.info+=VcfReader::INFO_SEPARATOR+MATEID_STR+"="+NEW_MATE_PREFIX+record.id;
             record.print(outstream);
             outstream << "\n";
-            // Writing the new mate record, if it needs to be created.
+            // Writing a new mate record if necessary
             if (!record.is_breakend_single() && !has_mate) {
+                pos2=record.get_breakend_pos();
                 outstream << chromosome2 << VcfReader::VCF_SEPARATOR << std::to_string(pos2) << VcfReader::VCF_SEPARATOR << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR << ref_sequences.at(chromosome2).at(pos2-1) << VcfReader::VCF_SEPARATOR;
                 record.get_alt_of_breakend_mate(ref_sequences,buffer);
-                outstream << buffer << VcfReader::VCF_SEPARATOR << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR << record.format;
+                outstream << buffer << VcfReader::VCF_SEPARATOR << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR << record.format;
                 for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
                 outstream << "\n";
             }
         }
         else if (record.sv_length<min_sv_length) { record.print(outstream); outstream << "\n"; }
         else {
+            chromosome_length=(int32_t)ref_sequences.at(record.chrom).length();
             if (record.sv_type==VcfReader::TYPE_DELETION) {
-                // Left side
-                c=ref_sequences.at(record.chrom).at(record.pos-1);
-                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << VcfReader::VCF_SEPARATOR << record.id << VcfReader::VCF_SEPARATOR;
-                outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::BREAKEND_CHAR_OPEN << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
-                outstream << record.format;
-                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
-                outstream << "\n";
-                // Right side
-                c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length+1-1);
-                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::VCF_SEPARATOR;
-                outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
-                outstream << c << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos) << VcfReader::BREAKEND_CHAR_CLOSE << c << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR;
-                outstream << record.format;
-                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
-                outstream << "\n";
+                if (record.pos+record.sv_length+1<=chromosome_length) {
+                    // Left side
+                    c=ref_sequences.at(record.chrom).at(record.pos-1);
+                    outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << VcfReader::VCF_SEPARATOR << record.id << VcfReader::VCF_SEPARATOR;
+                    outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::BREAKEND_CHAR_OPEN << VcfReader::VCF_SEPARATOR;
+                    outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                    outstream << record.format;
+                    for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                    outstream << "\n";
+                    // Right side
+                    c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length+1-1);
+                    outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::VCF_SEPARATOR;
+                    outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                    outstream << c << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos) << VcfReader::BREAKEND_CHAR_CLOSE << c << VcfReader::VCF_SEPARATOR;
+                    outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR;
+                    outstream << record.format;
+                    for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                    outstream << "\n";
+                }
+                else { /* Filtered out: this would be a single breakend with no inserted sequence. */ }
             }
             else if (record.sv_type==VcfReader::TYPE_INVERSION) {
+                if (record.pos+record.sv_length>chromosome_length) record.sv_length=(int32_t)(chromosome_length-(record.pos+1));
                 // Adjacency 1, left side.
                 c=ref_sequences.at(record.chrom).at(record.pos-1);
-                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << record.id << VcfReader::VCF_SEPARATOR;
-                outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+length) << VcfReader::BREAKEND_CHAR_CLOSE << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << VcfReader::VCF_SEPARATOR << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length) << VcfReader::BREAKEND_CHAR_CLOSE << VcfReader::VCF_SEPARATOR;
+                outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
                 outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
                 outstream << record.format;
                 for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
@@ -174,37 +165,40 @@ int main (int argc, char* argv[]) {
                 outstream << record.chrom << VcfReader::VCF_SEPARATOR;
                 outstream << std::to_string(record.pos+record.sv_length) << VcfReader::VCF_SEPARATOR << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
                 outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos) << VcfReader::BREAKEND_CHAR_CLOSE << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
                 outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR;
                 outstream << record.format;
                 for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
                 outstream << "\n";
-                // Adjacency 2, left side.
-                c=ref_sequences.at(record.chrom).at(record.pos+1-1);
-                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.pos+1) << VcfReader::VCF_SEPARATOR;
-                outstream << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
-                outstream << c << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::BREAKEND_CHAR_OPEN << c << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
-                outstream << record.format;
-                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
-                outstream << "\n";
-                // Adjacency 1, right side.
-                c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length+1-1);
-                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.pos+record.sv_length+1) << VcfReader::VCF_SEPARATOR;
-                outstream << NEW_MATE_PREFIX << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
-                outstream << c << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+1) << VcfReader::BREAKEND_CHAR_OPEN << c << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
-                outstream << record.format;
-                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
-                outstream << "\n";
+                if (record.pos+record.sv_length+1<=chromosome_length) {
+                    // Adjacency 2, left side.
+                    c=ref_sequences.at(record.chrom).at(record.pos+1-1);
+                    outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                    outstream << std::to_string(record.pos+1) << VcfReader::VCF_SEPARATOR;
+                    outstream << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                    outstream << c << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::BREAKEND_CHAR_OPEN << c << VcfReader::VCF_SEPARATOR;
+                    outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                    outstream << record.format;
+                    for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                    outstream << "\n";
+                    // Adjacency 2, right side.
+                    c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length+1-1);
+                    outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                    outstream << std::to_string(record.pos+record.sv_length+1) << VcfReader::VCF_SEPARATOR;
+                    outstream << NEW_MATE_PREFIX << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                    outstream << c << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+1) << VcfReader::BREAKEND_CHAR_OPEN << c << VcfReader::VCF_SEPARATOR;
+                    outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                    outstream << record.format;
+                    for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                    outstream << "\n";
+                }
             }
             else if (record.sv_type==VcfReader::TYPE_DUPLICATION) {
+                if (record.pos+record.sv_length>chromosome_length) record.sv_length=(int32_t)(chromosome_length-(record.pos+1));
                 // Left side
                 c=ref_sequences.at(record.chrom).at(record.pos+1-1);
                 outstream << record.chrom << VcfReader::VCF_SEPARATOR;
@@ -212,7 +206,7 @@ int main (int argc, char* argv[]) {
                 outstream << record.id << VcfReader::VCF_SEPARATOR;
                 outstream << c << VcfReader::VCF_SEPARATOR;
                 outstream << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length) << VcfReader::BREAKEND_CHAR_CLOSE << c << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
                 outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
                 outstream << record.format;
                 for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
@@ -224,7 +218,7 @@ int main (int argc, char* argv[]) {
                 outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
                 outstream << c << VcfReader::VCF_SEPARATOR;
                 outstream << c << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+1) << VcfReader::BREAKEND_CHAR_OPEN << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
                 outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR;
                 outstream << record.format;
                 for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
@@ -232,27 +226,31 @@ int main (int argc, char* argv[]) {
             }
             else if (record.sv_type==VcfReader::TYPE_INSERTION && !record.is_symbolic) {
                 // Adjacency 1
-                c=ref_sequences.at(record.chrom).at(record.pos-1);
-                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << VcfReader::VCF_SEPARATOR << record.id << VcfReader::VCF_SEPARATOR;
-                outstream << c << VcfReader::VCF_SEPARATOR;
-                outstream << c << record.alt.substr(1,single_breakend_length) << VcfReader::VCF_MISSING_CHAR << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << VcfReader::VCF_SEPARATOR;
-                outstream << record.format;
-                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
-                outstream << "\n";
+                if (record.pos>0) {
+                    c=ref_sequences.at(record.chrom).at(record.pos-1);
+                    outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << VcfReader::VCF_SEPARATOR << record.id << VcfReader::VCF_SEPARATOR;
+                    outstream << c << VcfReader::VCF_SEPARATOR;
+                    outstream << c << record.alt.substr(1,single_breakend_length) << VcfReader::VCF_MISSING_CHAR << VcfReader::VCF_SEPARATOR;
+                    outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << VcfReader::VCF_SEPARATOR;
+                    outstream << record.format;
+                    for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                    outstream << "\n";
+                }
                 // Adjacency 2
-                c=ref_sequences.at(record.chrom).at(record.pos+1-1);
-                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.pos+1) << VcfReader::VCF_SEPARATOR;
-                outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
-                outstream << c << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::VCF_MISSING_CHAR << record.info.substr(record.info.length()-single_breakend_length,single_breakend_length) << c << VcfReader::VCF_SEPARATOR;
-                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
-                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << VcfReader::VCF_SEPARATOR;
-                outstream << record.format;
-                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
-                outstream << "\n";
+                if (record.pos+1<=chromosome_length) {
+                    c=ref_sequences.at(record.chrom).at(record.pos+1-1);
+                    outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                    outstream << std::to_string(record.pos+1) << VcfReader::VCF_SEPARATOR;
+                    outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                    outstream << c << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::VCF_MISSING_CHAR << record.alt.substr(record.alt.length()-single_breakend_length,single_breakend_length) << c << VcfReader::VCF_SEPARATOR;
+                    outstream << (record.qual==-1?VcfReader::VCF_MISSING_STRING:std::to_string(record.qual)) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                    outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << VcfReader::VCF_SEPARATOR;
+                    outstream << record.format;
+                    for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                    outstream << "\n";
+                }
             }
             else { record.print(outstream); outstream << "\n"; }
         }

--- a/src/executable/clean_bnds.cpp
+++ b/src/executable/clean_bnds.cpp
@@ -1,0 +1,263 @@
+#include "fasta.hpp"
+
+
+#include "windows.hpp"
+#include "Timer.hpp"
+#include "CLI11.hpp"
+#include "bed.hpp"
+
+#include <unordered_map>
+#include <exception>
+#include <stdexcept>
+#include <iostream>
+#include <limits>
+
+using std::numeric_limits;
+using std::unordered_map;
+using std::runtime_error;
+using std::exception;
+using std::ifstream;
+using std::ofstream;
+using std::thread;
+using std::atomic;
+using std::mutex;
+using std::cerr;
+using std::min;
+using std::max;
+using std::cref;
+using std::ref;
+
+
+using namespace sv_merge;
+
+
+
+/**
+ * Sets `header` to an updated version of the header of `input_vcf`.
+ */
+void get_vcf_header(const path& input_vcf, string& header) {
+    bool is_last_line;
+    char c;
+    size_t i;
+    string line;
+    ifstream file;
+
+    file.open(input_vcf,std::ifstream::in);
+    if (!file.is_open() || !file.good()) throw runtime_error("ERROR: could not read file: "+input_vcf.string());
+    header.clear();
+    while (!file.eof()) {
+        line.clear();
+        c=(char)file.peek();
+        if (c!=VcfReader::VCF_COMMENT) break;
+        line.push_back(c);
+        while (file.get(c)) {
+            if (c==VcfReader::LINE_END || c==EOF) break;
+            else line.push_back(c);
+        }
+        is_last_line=true;
+        for (i=0; i<VcfReader::VCF_HEADER_PREFIX_LENGTH; i++) {
+            if (toupper(line.at(i))!=VcfReader::VCF_HEADER_PREFIX.at(i)) { is_last_line=false; break; }
+        }
+        if (is_last_line) header.append("##INFO=<ID=MATEID,Number=1,Type=String,Description=\"ID of mate breakends\">\n");
+        header.append(line+"\n");
+    }
+    file.close();
+}
+
+
+/**
+ * - Removes symbolic breakends and virtual telomeric breakends.
+ * - Ensures that REF and ALT in BND records use the same first character, and that such a character is the same as
+ *   in the ref.
+ * - Ensures that every non-single BND record has a mate.
+ * - Discards BND records whose ALT allele does not conform to the VCF spec (e.g. sniffles can output ACNNNNNNNNNNNNNNN
+ *   in the ALT of a BND record).
+ * - Transforms long non-BND calls into sets of BNDs.
+ *
+ * Remark: the output VCF is not sorted.
+ */
+int main (int argc, char* argv[]) {
+    bool has_mate;
+    char c;
+    int32_t n_records, min_sv_length, single_breakend_length, pos2, length;
+    string header, current_chromosome, chromosome2, buffer;
+    path ref_fasta, input_vcf, output_vcf;
+
+    const string MATEID_STR = "MATEID";
+    const string NEW_MATE_PREFIX = "mate_of_";
+    const string SECOND_ADJACENCY_SUFFIX = "_prime";
+
+    CLI::App app{"App description"};
+    app.add_option("--input_vcf",input_vcf,"Path to input VCF file, which might contain both BND and non-BND records.")->required();
+    app.add_option("--ref_fasta",ref_fasta,"Path to reference sequence FASTA file that corresponds to VCF")->required();
+    app.add_option("--min_sv_length",min_sv_length,"Only calls this length or longer are transformed into BNDs. Every other call is kept intact and printed to the output.")->required();
+    app.add_option("--single_breakend_length",single_breakend_length,"A long INS is converted to a pair of single breakends with this number of bases each.")->required();
+    app.add_option("--output_vcf",output_vcf,"Path to output VCF file")->required();
+    CLI11_PARSE(app,argc,argv);
+    if (min_sv_length<(single_breakend_length<<1)) throw runtime_error("The following command-line arguments are inconsistent: min_sv_length="+std::to_string(min_sv_length)+" single_breakend_length="+std::to_string(single_breakend_length));
+
+    cerr << "Loading the reference...\n";
+    unordered_map<string,string> ref_sequences;
+    for_sequence_in_fasta_file(ref_fasta, [&](const Sequence& s){ ref_sequences[s.name] = s.sequence; });
+    cerr << "done\n";
+
+    cerr << "Reading the VCF... " << '\n';
+    VcfReader vcf_reader(input_vcf);
+    vcf_reader.min_qual = numeric_limits<float>::min();
+    vcf_reader.min_sv_length = 1;
+    vcf_reader.progress_n_lines = 100'000;
+    ofstream outstream(output_vcf.string());
+    if (!outstream.good() || !outstream.is_open()) throw runtime_error("ERROR: file could not be written: "+output_vcf.string());
+    get_vcf_header(input_vcf,header);
+    outstream << header;
+    n_records=0;
+    vcf_reader.for_record_in_vcf([&](VcfRecord& record) {
+        n_records++;
+        if (n_records%100'000==0) cerr << "Processed " << std::to_string(n_records) << " records...\n";
+        if (record.sv_type==-1) { record.print(outstream); outstream << "\n"; return; }
+        else if (record.sv_type==VcfReader::TYPE_BREAKEND) {
+            if (record.is_symbolic || !record.is_valid_bnd_alt() || record.is_breakend_virtual(ref_sequences)) return;
+            has_mate=record.get_info_field(MATEID_STR,0,buffer)!=string::npos;
+            // Fixing REF and ALT character at POS, if unknown.
+            if (toupper(record.ref.at(0))==VcfReader::UNKNOWN_BASE) record.ref.at(0)=ref_sequences.at(record.chrom).at(record.pos-1);
+            length=record.alt.length();
+            if (toupper(record.alt.at(0))==VcfReader::UNKNOWN_BASE) record.alt.at(0)=ref_sequences.at(record.chrom).at(record.pos-1);
+            if (toupper(record.alt.at(length-1))==VcfReader::UNKNOWN_BASE) record.alt.at(length-1)=ref_sequences.at(record.chrom).at(record.pos-1);
+            if (!record.is_breakend_single() && !has_mate) record.info+=VcfReader::INFO_SEPARATOR+MATEID_STR+"="+NEW_MATE_PREFIX+record.id;
+            record.print(outstream);
+            outstream << "\n";
+            // Writing the new mate record, if it needs to be created.
+            if (!record.is_breakend_single() && !has_mate) {
+                outstream << chromosome2 << VcfReader::VCF_SEPARATOR << std::to_string(pos2) << VcfReader::VCF_SEPARATOR << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR << ref_sequences.at(chromosome2).at(pos2-1) << VcfReader::VCF_SEPARATOR;
+                record.get_alt_of_breakend_mate(ref_sequences,buffer);
+                outstream << buffer << VcfReader::VCF_SEPARATOR << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+            }
+        }
+        else if (record.sv_length<min_sv_length) { record.print(outstream); outstream << "\n"; }
+        else {
+            if (record.sv_type==VcfReader::TYPE_DELETION) {
+                // Left side
+                c=ref_sequences.at(record.chrom).at(record.pos-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << VcfReader::VCF_SEPARATOR << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::BREAKEND_CHAR_OPEN << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+                // Right side
+                c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length+1-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::VCF_SEPARATOR;
+                outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos) << VcfReader::BREAKEND_CHAR_CLOSE << c << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+            }
+            else if (record.sv_type==VcfReader::TYPE_INVERSION) {
+                // Adjacency 1, left side.
+                c=ref_sequences.at(record.chrom).at(record.pos-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+length) << VcfReader::BREAKEND_CHAR_CLOSE << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+                // Adjacency 1, right side.
+                c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.pos+record.sv_length) << VcfReader::VCF_SEPARATOR << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR << c << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos) << VcfReader::BREAKEND_CHAR_CLOSE << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+                // Adjacency 2, left side.
+                c=ref_sequences.at(record.chrom).at(record.pos+1-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.pos+1) << VcfReader::VCF_SEPARATOR;
+                outstream << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length+1) << VcfReader::BREAKEND_CHAR_OPEN << c << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+                // Adjacency 1, right side.
+                c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length+1-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.pos+record.sv_length+1) << VcfReader::VCF_SEPARATOR;
+                outstream << NEW_MATE_PREFIX << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+1) << VcfReader::BREAKEND_CHAR_OPEN << c << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << SECOND_ADJACENCY_SUFFIX << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+            }
+            else if (record.sv_type==VcfReader::TYPE_DUPLICATION) {
+                // Left side
+                c=ref_sequences.at(record.chrom).at(record.pos+1-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.pos+1) << VcfReader::VCF_SEPARATOR;
+                outstream << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::BREAKEND_CHAR_CLOSE << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+record.sv_length) << VcfReader::BREAKEND_CHAR_CLOSE << c << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+                // Right side
+                c=ref_sequences.at(record.chrom).at(record.pos+record.sv_length-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.pos+record.sv_length) << VcfReader::VCF_SEPARATOR;
+                outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::BREAKEND_CHAR_OPEN << record.chrom << VcfReader::BREAKEND_SEPARATOR << std::to_string(record.pos+1) << VcfReader::BREAKEND_CHAR_OPEN << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << MATEID_STR << "=" << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+            }
+            else if (record.sv_type==VcfReader::TYPE_INSERTION && !record.is_symbolic) {
+                // Adjacency 1
+                c=ref_sequences.at(record.chrom).at(record.pos-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR << std::to_string(record.pos) << VcfReader::VCF_SEPARATOR << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR;
+                outstream << c << record.alt.substr(1,single_breakend_length) << VcfReader::VCF_MISSING_CHAR << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+                // Adjacency 2
+                c=ref_sequences.at(record.chrom).at(record.pos+1-1);
+                outstream << record.chrom << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.pos+1) << VcfReader::VCF_SEPARATOR;
+                outstream << NEW_MATE_PREFIX << record.id << VcfReader::VCF_SEPARATOR;
+                outstream << c << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::VCF_MISSING_CHAR << record.info.substr(record.info.length()-single_breakend_length,single_breakend_length) << c << VcfReader::VCF_SEPARATOR;
+                outstream << std::to_string(record.qual) << VcfReader::VCF_SEPARATOR << record.filter << VcfReader::VCF_SEPARATOR;
+                outstream << VcfReader::SVTYPE_STR << "=" << VcfReader::BND_STR << VcfReader::INFO_SEPARATOR << VcfReader::VCF_SEPARATOR;
+                outstream << record.format;
+                for (const auto& item: record.genotypes) outstream << VcfReader::VCF_SEPARATOR << item;
+                outstream << "\n";
+            }
+            else { record.print(outstream); outstream << "\n"; }
+        }
+    });
+    outstream.close();
+    cerr << "done.\n";
+    return 0;
+}

--- a/src/executable/clean_bnds.cpp
+++ b/src/executable/clean_bnds.cpp
@@ -58,7 +58,9 @@ void get_vcf_header(const path& input_vcf, string& header) {
  *   in the ALT of a BND record).
  * - Transforms long non-BND calls into sets of BNDs.
  *
- * Remark: the output VCF is not sorted.
+ * Remark: the output VCF is not sorted: if it is used for inter-sample SV merging, it should be sorted. If it is used
+ * for inter-sample SV merging or for intra-sample SV filtering, it should be post-processed to make a decision on a
+ * large call from information on its BNDs.
  */
 int main (int argc, char* argv[]) {
     bool has_mate;

--- a/src/executable/evaluate.cpp
+++ b/src/executable/evaluate.cpp
@@ -590,7 +590,8 @@ void evaluate(
             true,
             true,
             force_unique_reads,
-            false
+            false,
+            flank_length
     );
 
     cerr << t << "Aligning haplotypes to variant graphs" << '\n';

--- a/src/executable/extract_reads_from_windows.cpp
+++ b/src/executable/extract_reads_from_windows.cpp
@@ -120,7 +120,8 @@ void extract(
                     get_qualities,
                     std::ref(job_index),
                     std::cref(tags_to_fetch),
-                    true
+                    true,
+                    0
             );
         } catch (const exception& e) {
             throw e;

--- a/src/executable/hapestry.cpp
+++ b/src/executable/hapestry.cpp
@@ -665,7 +665,9 @@ void hapestry(
                 region_transmaps,
                 true,
                 force_unique_reads,
-                true
+                true,
+                false,
+                flank_length
         );
     }
     else{
@@ -682,7 +684,8 @@ void hapestry(
                 false,
                 false,
                 force_unique_reads,
-                true
+                true,
+                flank_length
         );
     }
 

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -95,9 +95,9 @@ void construct_windows_from_vcf_and_bed(
 
             r.get_reference_coordinates(use_confidence_intervals, coord);
 
-            // Skip large events in the population
-            // TODO: address these as breakpoints in the VariantGraph and avoid constructing windows as intervals
-            // for very large events
+            // Skip large events in the population.
+            // A better solution consists in pre-processing the VCF to transform every large event into a set of BNDs:
+            // see `clean_bnds.cpp`.
             if (coord.second - coord.first > interval_max_length){
                 vcf_omissions.back().second++;
                 return;


### PR DESCRIPTION
Includes `dev_bnd`. 

Remark: given an alignment involving a read R, a path P, and a call C that might occur multiple times in P, `length_of_evaluated_region` is currently set to the max over all occurrences of C in P, and `identity` is set to the max over all occurrences of C in P. This makes `length_of_evaluated_region` incomparable to the values in the old implementation (it is generally equal or bigger, but it can also be smaller).
