### PR TITLE
Integrate compression algos from @fabio-cunial, add cpptrace, and make docker image 2 tiered

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
     message(STATUS "---- Building with optimization ----")
 
     # Standard compilation
-    add_definitions(-O3 -Wall)              # Much optimization
+    add_definitions(-g -O3 -Wall)              # Much optimization, but retain debug symbols
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,6 +517,38 @@ message(STATUS "INSTALL_DIR: ${INSTALL_DIR}")
 ##############################################
 # ------------------------------------------ #
 # -------- LINKING EXTERNAL LIBRARY -------- #
+# ---------------- cpptrace ---------------- #
+# ------------------------------------------ #
+##############################################
+
+include(ExternalProject)
+
+message(STATUS "CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
+message(STATUS "CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
+message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+
+include(FetchContent)
+
+FetchContent_Declare(
+        cpptrace
+        GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+        GIT_TAG        v0.7.5
+)
+FetchContent_MakeAvailable(cpptrace)
+
+include_directories(
+        ${cpptrace_SOURCE_DIR}/include
+        ${libdwarf_SOURCE_DIR}
+#        ${libunwind_SOURCE_DIR}
+)
+
+message(STATUS "cpptrace location: ${cpptrace_SOURCE_DIR}")
+
+
+##############################################
+# ------------------------------------------ #
+# -------- LINKING EXTERNAL LIBRARY -------- #
 # ---------------- mimalloc ---------------- #
 # ------------------------------------------ #
 ##############################################
@@ -570,6 +602,7 @@ set(TESTS
         test_binary_sequence_memory
         test_bisection_method
         test_command_timeout
+        test_cpptrace
         test_fasta
         test_gaf
         test_gaf_summary
@@ -613,6 +646,7 @@ foreach(FILENAME_PREFIX ${TESTS})
     target_link_libraries(${FILENAME_PREFIX}
             sv_merge
             Threads::Threads
+            cpptrace::cpptrace
             htslib
             bdsg
             ${ZLIB_LIBRARIES}
@@ -669,6 +703,7 @@ foreach(FILENAME_PREFIX ${EXECUTABLES})
     target_link_libraries(${FILENAME_PREFIX}
             sv_merge
             Threads::Threads
+            cpptrace::cpptrace
             htslib
             bdsg
             ${ZLIB_LIBRARIES}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -152,18 +152,24 @@ RUN pip3 install torch torchvision torchaudio --index-url https://download.pytor
 RUN pip3 install vcfpy
 
 # HAPESTRY
-ARG HAPESTRY_COMMIT=384780860121d3611ae3f58d1da0bf9e8edc32ed
 RUN git clone https://github.com/rlorigro/sv_merge.git
 
-WORKDIR /hapestry/sv_merge
-
-RUN git checkout ${HAPESTRY_COMMIT} \
-    && mkdir build
-
+# Initially build with `dev` branch commit so that we can compile all the common dependencies like ORTools, htslib, etc
 WORKDIR /hapestry/sv_merge/build
 
+# This is an arbitrarily close commit to whichever commit we ultimately want. If building becomes slow, then ratchet up
+ARG HAPESTRY_COMMIT=60122fe34b8f6abbb09f9a5bf6ae339f5464c4b3
+RUN git checkout ${HAPESTRY_COMMIT}
+
 RUN cmake ..
-RUN make -j 31
+RUN make -j 16
+
+# Now checkout any specific changes/branches we want and rebuild WITHOUT REDOWNLOADING all the dependencies
+ARG HAPESTRY_COMMIT=1f8220fa136cc9fe583e9a32631a8cdd20ae7717
+RUN git checkout ${HAPESTRY_COMMIT}
+
+RUN cmake .. -Ddev=1
+RUN make -j 16
 
 WORKDIR /hapestry
 

--- a/inc/TransitiveMap.hpp
+++ b/inc/TransitiveMap.hpp
@@ -282,7 +282,7 @@ public:
      *
      * @param used temporary space.
      */
-    void decompress_samples(vector<bool>& used);
+    void decompress_samples();
 
     /**
      * Adds to object variable `present_haps` all the mandatory haplotypes, and to `present_edges` the corresponding

--- a/inc/TransitiveMap.hpp
+++ b/inc/TransitiveMap.hpp
@@ -165,7 +165,7 @@ public:
     pair<int64_t,int64_t> get_n_paths_of_read(int64_t read_id) const;
 
     /// Writing
-    void write_edge_info_to_csv(path output_path, const VariantGraph& variant_graph) const;
+    void write_edge_info_to_csv(path output_path, const VariantGraph& variant_graph, bool use_sample_id = false) const;
 
     /// Clearing
     void clear_non_samples();

--- a/inc/TransitiveMap.hpp
+++ b/inc/TransitiveMap.hpp
@@ -87,6 +87,7 @@ public:
     /// Accessing
     bool empty() const;
 
+    size_t get_edge_count() const;
     size_t get_read_count() const;
     size_t get_path_count() const;
     size_t get_sample_count() const;
@@ -363,5 +364,7 @@ public:
     static float get_edge_weight(float weight, float weight_quantum);
 };
 
+/// WARNING: DOES NOT COMPARE EDGE WEIGHTS, ONLY COMPARES EDGE PRESENCE/ABSENCE
+bool operator==(const TransMap& a, const TransMap& b);
 
 }

--- a/inc/TransitiveMap.hpp
+++ b/inc/TransitiveMap.hpp
@@ -17,6 +17,7 @@ using std::to_string;
 using std::vector;
 using std::string;
 using std::pair;
+using std::byte;
 
 
 namespace sv_merge {
@@ -34,6 +35,12 @@ class TransMap {
 
     // Pains me to add yet another map but here it is
     unordered_map<int64_t,bool> sequence_reversals;
+
+    /**
+     * For every original sample, the sample it was compressed into. Used only by procedures `compress()` and
+     * `decompress()`.
+     */
+    unordered_map<string,string> sample_to_compressed_sample;
 
 public:
     static const string sample_node_name;
@@ -109,6 +116,7 @@ public:
 
     string get_sample_of_read(const string& read_name) const;
     void for_each_sample_of_read(const string& read_name, const function<void(const string& name, int64_t id)>& f) const;
+    void for_each_sample_of_read(const int64_t& read_id, const function<void(int64_t id)>& f) const;
     void for_each_sample_of_path(const string& path_name, const function<void(const string& name, int64_t id)>& f) const;
     void for_each_sample_of_path(int64_t id, const function<void(const string& name, int64_t id)>& f) const;
 
@@ -143,14 +151,44 @@ public:
     /// Copying/subsetting
     void extract_sample_as_transmap(const string& sample_name, TransMap& result);
 
-    /// Reversible modifications
-
+    /// Reversible modification
     // Restructure the transmap by duplicating any paths/haps that are used by multiple samples, so that the resulting
     // transmap is essentially a collection of independent sample->read->hap mappings. For this process to be reversible
     // it requires that we keep track of which parent path corresponded to which duplicated child path. We don't
     // store this in the Transmap members because it is rarely used and would be a waste.
-    void detangle_sample_paths(unordered_map<string,string>& hapmap);
-    void retangle_sample_paths(const unordered_map<string,string>& hapmap);
+    // !! Currently UNTESTED w.r.t. any compression methods !!
+    void detangle_sample_paths(unordered_map<string, string> &hapmap);
+
+    void retangle_sample_paths(const unordered_map<string, string> &hapmap);
+
+    /// Compressing
+    /**
+     * Two reads are considered identical iff they connect to the same haplotypes with the same weights (possibly
+     * after quantization). The procedure collapses all identical reads onto a single node, which becomes connected to
+     * all the samples of the reads in its equivalence class (breaking the assumption that a read is connected to just
+     * one sample).
+     *
+     * Two samples are considered identical iff their reads belong to the same set of read clusters (regardless of
+     * how many reads in each sample belong to each cluster). Only one sample per equivalence class is kept, and the
+     * mapping is stored in object variable `sample_to_compressed_sample`.
+     *
+     * Remark: the procedure assumes that haplotypes are already distinct from previous steps, and it does not try to
+     * compress them.
+     *
+     * Remark: the procedure sets object variables `n_reads, n_read_clusters, n_samples, n_sample_clusters`.
+     *
+     * @param weight_quantum if nonzero, read-haplotype weights are divided by this and floored before being compared
+     * exactly;
+     * @param mode the weight of every read-hap edge is set to the max (mode=0), min (mode=1), sum (mode=2) or avg
+     * (mode=3) of all the edges that were collapsed onto it.
+     */
+    void compress(float weight_quantum, uint64_t mode);
+
+    /**
+     * Reintroduces a node for every compressed sample using object variable `sample_to_compressed_sample` (which is
+     * cleared when this procedure returns). The rest of the graph remains compressed.
+     */
+    void decompress_samples();
 };
 
 

--- a/inc/VectorHeteroGraph.hpp
+++ b/inc/VectorHeteroGraph.hpp
@@ -294,7 +294,7 @@ template<class T> void HeteroGraph<T>::update_first_of_type() {
     size_t i;
     size_t length;
 
-    if (is_first_of_type_updated) return;
+    // if (is_first_of_type_updated) return;
     first_of_type.clear();
     for (auto& element: edges) {
         length=element.second.size();
@@ -551,20 +551,20 @@ template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(int64_t id, cha
     if (result==edges.end()) return;
 
     // Iterate all edges, but only operate on the specified type
-    if (is_first_of_type_updated) {
-        int64_t first = first_of_type.at(type).at(id);
-        const size_t length = result->second.size();
-        for (size_t i=first; i<length; i++) {
-            const int64_t id_b = result->second.at(i).first;
-            if (nodes.at(id_b).type!=type) break;
-            f(id_b);
-        }
-    }
-    else {
+    // if (is_first_of_type_updated) {
+    //     int64_t first = first_of_type.at(type).at(id);
+    //     const size_t length = result->second.size();
+    //     for (size_t i=first; i<length; i++) {
+    //         const int64_t id_b = result->second.at(i).first;
+    //         if (nodes.at(id_b).type!=type) break;
+    //         f(id_b);
+    //     }
+    // }
+    // else {
         for (const auto& [id_b,w]: result->second) {
             if (nodes.at(id_b).type==type) f(id_b);
         }
-    }
+    // }
 }
 
 

--- a/inc/VectorHeteroGraph.hpp
+++ b/inc/VectorHeteroGraph.hpp
@@ -523,12 +523,22 @@ template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(const string& n
 
     // Check if there are any edges from this node
     const auto result = edges.find(id);
-    if (result==edges.end()) return;
+    if (result == edges.end()) {
+        return;
+    }
 
     // Iterate all edges, but only operate on the specified type
     if (is_first_of_type_updated) {
-        int64_t first = first_of_type.at(type).at(id);
+        const auto result2 = first_of_type.at(type).find(id);
+
+        // Some nodes may have no neighbors
+        if (result2 == first_of_type.at(type).end()) {
+            return;
+        }
+
+        auto first = result2->second;
         const size_t length = result->second.size();
+
         for (size_t i=first; i<length; i++) {
             const int64_t id_b = result->second.at(i).first;
             const auto &node = nodes.at(id_b);
@@ -548,35 +558,53 @@ template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(const string& n
 template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(int64_t id, char type, const function<void(int64_t)>& f) const{
     // Check if there are any edges from this node
     const auto result = edges.find(id);
-    if (result==edges.end()) return;
+    if (result == edges.end()) {
+        return;
+    }
 
     // Iterate all edges, but only operate on the specified type
-    // if (is_first_of_type_updated) {
-    //     int64_t first = first_of_type.at(type).at(id);
-    //     const size_t length = result->second.size();
-    //     for (size_t i=first; i<length; i++) {
-    //         const int64_t id_b = result->second.at(i).first;
-    //         if (nodes.at(id_b).type!=type) break;
-    //         f(id_b);
-    //     }
-    // }
-    // else {
+    if (is_first_of_type_updated) {
+        const auto result2 = first_of_type.at(type).find(id);
+
+        if (result2 == first_of_type.at(type).end()) {
+            return;
+        }
+
+        auto first = result2->second;
+        const size_t length = result->second.size();
+
+        for (size_t i=first; i<length; i++) {
+            const int64_t id_b = result->second.at(i).first;
+            if (nodes.at(id_b).type!=type) break;
+            f(id_b);
+        }
+    }
+    else {
         for (const auto& [id_b,w]: result->second) {
             if (nodes.at(id_b).type==type) f(id_b);
         }
-    // }
+    }
 }
 
 
 template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(int64_t id, char type, const function<void(int64_t, float w)>& f) const{
     // Check if there are any edges from this node
     const auto result = edges.find(id);
-    if (result==edges.end()) return;
+    if (result == edges.end()) {
+        return;
+    }
 
     // Iterate all edges, but only operate on the specified type
     if (is_first_of_type_updated) {
-        int64_t first = first_of_type.at(type).at(id);
+        const auto result2 = first_of_type.at(type).find(id);
+
+        if (result2 == first_of_type.at(type).end()) {
+            return;
+        }
+
+        auto first = result2->second;
         const size_t length = result->second.size();
+
         for (size_t i=first; i<length; i++) {
             const int64_t id_b = result->second.at(i).first;
             if (nodes.at(id_b).type!=type) break;

--- a/inc/VectorHeteroGraph.hpp
+++ b/inc/VectorHeteroGraph.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+// To get the pair hash fn, we use the external lib, otherwise is declared twice
+#include "bdsg/internal/hash_map.hpp"
+
 #include <unordered_map>
 #include <unordered_set>
 #include <functional>
@@ -20,6 +23,8 @@ using std::string;
 using std::queue;
 using std::pair;
 using std::cerr;
+using std::min;
+using std::max;
 
 
 namespace sv_merge {
@@ -118,6 +123,7 @@ public:
 
     bool has_edge(int64_t id_a, int64_t id_b) const;
     bool has_node(const string& name) const;
+    bool has_node(int64_t id) const;
 
     /// Global iterators
     void for_each_edge(const function<void(const string& a,const string& b, float weight)>& f) const;
@@ -130,6 +136,12 @@ public:
             float min_edge_weight,
             const function<bool(const T& node)>& criteria,
             const function<void(const T& node, int64_t id)>& f) const;
+
+    void for_edge_in_bfs(
+            const string& start_name,
+            float min_edge_weight,
+            const function<bool(const T& node)>& criteria,
+            const function<void(const T& a, int64_t a_id, const T& b, int64_t b_id)>& f) const;
 
     /// Local iterators
     void for_each_neighbor(const string& name, const function<void(const T& neighbor, int64_t id)>& f) const;
@@ -657,6 +669,42 @@ template<class T> void HeteroGraph<T>::for_node_in_bfs(
             if (visited.find(n_other) == visited.end() and criteria(nodes.at(n_other)) == true) {
                 q.emplace(n_other);
                 visited.emplace(n_other);
+            }
+        }
+    }
+}
+
+
+template<class T> void HeteroGraph<T>::for_edge_in_bfs(
+        const string& start_name,
+        float min_edge_weight,
+        const function<bool(const T& node)>& criteria,
+        const function<void(const T& a, int64_t a_id, const T& b, int64_t b_id)>& f) const{
+    auto start_id = name_to_id(start_name);
+
+    unordered_set<pair <int64_t, int64_t> > visited;
+    queue<int64_t> q;
+
+    q.emplace(start_id);
+
+    while (not q.empty()){
+        auto n = q.front();
+        q.pop();
+
+        // Iterate all types indiscriminately
+        for (const auto& [n_other,w]: edges.at(n)) {
+            if (w < min_edge_weight){
+                continue;
+            }
+
+            // Canonical representation of edge
+            pair<int64_t,int64_t> e = {min(n,n_other), max(n,n_other)};
+
+            if (not visited.contains(e) and criteria(nodes.at(n_other)) == true) {
+                q.emplace(n_other);
+                visited.emplace(e);
+
+                f(nodes.at(e.first), e.first, nodes.at(e.second), e.second);
             }
         }
     }

--- a/inc/VectorHeteroGraph.hpp
+++ b/inc/VectorHeteroGraph.hpp
@@ -294,11 +294,11 @@ template<class T> void HeteroGraph<T>::update_first_of_type() {
     size_t i;
     size_t length;
 
-    // if (is_first_of_type_updated) return;
+    if (is_first_of_type_updated) return;
     first_of_type.clear();
     for (auto& element: edges) {
         length=element.second.size();
-        type='_';
+        type='\0';
         for (i=0; i<length; i++) {
             current_type=nodes.at(element.second.at(i).first).type;
             if (current_type!=type) {
@@ -529,6 +529,10 @@ template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(const string& n
 
     // Iterate all edges, but only operate on the specified type
     if (is_first_of_type_updated) {
+        if (not first_of_type.contains(type)) {
+            return;
+        }
+
         const auto result2 = first_of_type.at(type).find(id);
 
         // Some nodes may have no neighbors
@@ -564,6 +568,10 @@ template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(int64_t id, cha
 
     // Iterate all edges, but only operate on the specified type
     if (is_first_of_type_updated) {
+        if (not first_of_type.contains(type)) {
+            return;
+        }
+
         const auto result2 = first_of_type.at(type).find(id);
 
         if (result2 == first_of_type.at(type).end()) {
@@ -596,6 +604,10 @@ template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(int64_t id, cha
 
     // Iterate all edges, but only operate on the specified type
     if (is_first_of_type_updated) {
+        if (not first_of_type.contains(type)) {
+            return;
+        }
+
         const auto result2 = first_of_type.at(type).find(id);
 
         if (result2 == first_of_type.at(type).end()) {
@@ -622,10 +634,23 @@ template<class T> void HeteroGraph<T>::for_each_neighbor_of_type(int64_t id, cha
 template<class T> bool HeteroGraph<T>::has_large_weight(int64_t root_id, char type_b, float delta) const {
     const auto result = edges.find(root_id);
     if (result==edges.end()) return false;
+
     for (const auto &[id_a, w]: result->second) {
         if (is_first_of_type_updated) {
+            if (not first_of_type.contains(type_b)) {
+                return false;
+            }
+
             const size_t length = result->second.size();
-            int64_t first = first_of_type.at(type_b).at(id_a);
+
+            const auto result2 = first_of_type.at(type_b).find(id_a);
+
+            if (result2 == first_of_type.at(type_b).end()) {
+                return false;
+            }
+
+            auto first = result2->second;
+
             for (size_t i=first; i<length; i++) {
                 const int64_t id_b = result->second.at(i).first;
                 if (nodes.at(id_b).type!=type_b) break;

--- a/inc/VectorHeteroGraph.hpp
+++ b/inc/VectorHeteroGraph.hpp
@@ -64,6 +64,11 @@ public:
     // Simple helper function to search a vector and update it (since edges are stored in vectors)
     void update_adjacency_list(int64_t id, float weight, vector<pair <int64_t,float> >& adjacencies);
 
+    /**
+     * Sorts the neighbors of every node by (type,id).
+     */
+    void sort_adjacency_lists();
+
     void add_edge(const string& name_a, const string& name_b, float weight);
     void add_edge(int64_t id_a, int64_t id_b, float weight);
     void remove_edge(const string& name_a, const string& name_b);
@@ -81,6 +86,11 @@ public:
     int64_t get_node_count() const;
     int64_t get_edge_count(int64_t id) const;
     pair<bool,float> try_get_edge_weight(int64_t id_a, int64_t id_b) const;
+
+    /**
+     * Assigns `new_weight` to both `id_a->id_b` and `id_b->id_a`, if they exist.
+     */
+    void update_edge_weight(int64_t id_a, int64_t id_b, float new_weight);
 
     bool has_edge(int64_t id_a, int64_t id_b) const;
     bool has_node(const string& name) const;
@@ -228,6 +238,15 @@ template<class T> void HeteroGraph<T>::update_adjacency_list(
 }
 
 
+template<class T> void HeteroGraph<T>::sort_adjacency_lists() {
+    for (auto& element: edges) {
+        std::sort(element.second.begin(), element.second.end(), [&](const pair <int64_t,float>& a, const pair <int64_t,float>& b) {
+            return (nodes.at(a.first).type<nodes.at(b.first).type || a.first<b.first);
+        });
+    }
+}
+
+
 template<class T> void HeteroGraph<T>::add_edge(const string& name_a, const string& name_b, float weight) {
     auto id_a = name_to_id(name_a);
     auto id_b = name_to_id(name_b);
@@ -266,7 +285,7 @@ template<class T> bool HeteroGraph<T>::has_edge(int64_t id_a, int64_t id_b) cons
 
 
 template<class T> bool HeteroGraph<T>::has_node(const string& name) const {
-    return id_map.find(name) != id_map.end();
+    return id_map.contains(name);
 }
 
 
@@ -293,6 +312,25 @@ template<class T> pair<bool,float> HeteroGraph<T>::try_get_edge_weight(int64_t i
     }
 
     return value;
+}
+
+
+template<class T> void HeteroGraph<T>::update_edge_weight(int64_t id_a, int64_t id_b, float new_weight) {
+    // Updating `a->b`, if it exists.
+    auto result = edges.find(id_a);
+    if (result!=edges.end()) {
+        auto& adjacencies = result->second;
+        auto ab = std::find_if(adjacencies.begin(),adjacencies.end(),[&](const pair<int64_t, float>& p){ return p.first==id_b; });
+        if (ab!=adjacencies.end()) (*ab).second=new_weight;
+    }
+
+    // Updating `b->a`, if it exists.
+    result=edges.find(id_b);
+    if (result!=edges.end()) {
+        auto& adjacencies = result->second;
+        auto ab = std::find_if(adjacencies.begin(),adjacencies.end(),[&](const pair<int64_t, float>& p){ return p.first==id_a; });
+        if (ab!=adjacencies.end()) (*ab).second=new_weight;
+    }
 }
 
 

--- a/inc/misc.hpp
+++ b/inc/misc.hpp
@@ -43,6 +43,7 @@ public:
     bool bam_not_hardclipped = false;
     bool write_hap_vcf = false;
     bool skip_nonessential_logs = false;
+    bool obscure_sample_names = false;
 };
 
 

--- a/inc_optimize/path_optimizer_mathopt.hpp
+++ b/inc_optimize/path_optimizer_mathopt.hpp
@@ -46,6 +46,7 @@ public:
         float min_read_hap_identity = 0.5;
         float d_weight = 1.0;
         float n_weight = 1.0;
+        float compress_quantum = 0;
         bool skip_solve = false;
         bool rescale_weights = false;
         bool use_quadratic_objective = false;

--- a/inc_optimize/path_optimizer_mathopt.hpp
+++ b/inc_optimize/path_optimizer_mathopt.hpp
@@ -51,6 +51,7 @@ public:
         bool use_quadratic_objective = false;
         bool use_golden_search = false;
         bool use_sum_constraints = true;
+        bool use_compression = false;
         bool samplewise = false;
         bool prune_with_d_min = false;
         bool use_ploidy_constraint = true;

--- a/inc_optimize/path_optimizer_mathopt.hpp
+++ b/inc_optimize/path_optimizer_mathopt.hpp
@@ -133,8 +133,6 @@ TerminationReason optimize_reads_with_d_and_n(
 
 TerminationReason optimize_reads_with_d_plus_n(
         TransMap& transmap,
-        Model& model,
-        PathVariables& vars,
         size_t n_threads,
         path output_dir,
         const OptimizerConfig& config,
@@ -171,6 +169,8 @@ TerminationReason optimize_read_feasibility(
 );
 
 TerminationReason optimize(TransMap& transmap, const OptimizerConfig& config, path subdir, bool write_solution = false);
+
+TerminationReason optimize_compressed(TransMap& transmap, const OptimizerConfig& config, path subdir, bool write_solution = false);
 
 TerminationReason optimize_samplewise(TransMap& transmap, const OptimizerConfig& config, path subdir, bool write_solution = false);
 

--- a/inc_optimize/path_optimizer_mathopt.hpp
+++ b/inc_optimize/path_optimizer_mathopt.hpp
@@ -133,6 +133,8 @@ TerminationReason optimize_reads_with_d_and_n(
 
 TerminationReason optimize_reads_with_d_plus_n(
         TransMap& transmap,
+        Model& model,
+        PathVariables& vars,
         size_t n_threads,
         path output_dir,
         const OptimizerConfig& config,

--- a/src/TransitiveMap.cpp
+++ b/src/TransitiveMap.cpp
@@ -861,9 +861,9 @@ void TransMap::partition(vector<TransMap>& maps) {
         component_size.emplace_back(new_map.get_sample_count());
         component_size.emplace_back(new_map.get_edge_count());
     });
-    cerr << "Number of connected components: " << to_string(component_id+1) << '\n';
-    cerr << "Component \t n_reads \t n_paths \t n_samples \t n_edges\n";
-    for (i=0; i<component_size.size(); i+=4) cerr << to_string(i/4) << '\t' << to_string(component_size.at(i)) << '\t' << to_string(component_size.at(i+1)) << '\t' << to_string(component_size.at(i+2)) << '\t' << to_string(component_size.at(i+3)) << '\n';
+    // cerr << "Number of connected components: " << to_string(component_id+1) << '\n';
+    // cerr << "Component \t n_reads \t n_paths \t n_samples \t n_edges\n";
+    // for (i=0; i<component_size.size(); i+=4) cerr << to_string(i/4) << '\t' << to_string(component_size.at(i)) << '\t' << to_string(component_size.at(i+1)) << '\t' << to_string(component_size.at(i+2)) << '\t' << to_string(component_size.at(i+3)) << '\n';
 
     // Collecting samples assigned to 2 components
     partitioned_samples.clear();
@@ -876,7 +876,7 @@ void TransMap::partition(vector<TransMap>& maps) {
         if (set_size>2) throw runtime_error("ERROR: the reads of sample "+sample_name+" were partitioned into "+to_string(set.size())+" connected components");
         else if (set_size==2) partitioned_samples.emplace_back(sample_name);
     });
-    cerr << "Number of samples assigned to 2 components: " << to_string(partitioned_samples.size()) << '\n';
+    // cerr << "Number of samples assigned to 2 components: " << to_string(partitioned_samples.size()) << '\n';
 }
 
 
@@ -978,7 +978,7 @@ void TransMap::compress_reads(float weight_quantum, bool verbose) {
         }
     }
     compared_weights.clear();
-    cerr << "n_reads=" << to_string(n_reads) << " -> n_read_clusters=" << to_string(n_clusters) <<  " (after compressing reads)\n";
+    // cerr << "n_reads=" << to_string(n_reads) << " -> n_read_clusters=" << to_string(n_clusters) <<  " (after compressing reads)\n";
     if (verbose) {
         cerr << "Read-hap weights after compression: \n";
         for (i=0; i<n_reads; i++) {
@@ -1060,7 +1060,7 @@ void TransMap::compress_samples(float weight_quantum) {
         }
     }
     compared_weights.clear();
-    cerr << "n_reads=" << to_string(n_reads) << " -> n_read_clusters=" << to_string(n_clusters) << " (across all unsolved samples)\n";
+    // cerr << "n_reads=" << to_string(n_reads) << " -> n_read_clusters=" << to_string(n_clusters) << " (across all unsolved samples)\n";
 
     cluster_size.reserve(n_clusters);
     for (i=0; i<n_clusters; i++) cluster_size.emplace_back(0);
@@ -1143,7 +1143,7 @@ void TransMap::compress_samples(float weight_quantum) {
         }
         i=next_i;
     }
-    if (!sample_to_container_sample.empty()) cerr << "Removed " << to_string(sample_to_container_sample.size()) << " contained samples with trivial haplotypes\n";
+    // if (!sample_to_container_sample.empty()) cerr << "Removed " << to_string(sample_to_container_sample.size()) << " contained samples with trivial haplotypes\n";
 
     // Preparing data structures for decompression
     sample_to_sample.clear();
@@ -1297,7 +1297,7 @@ void TransMap::compress_haplotypes_global(float weight_quantum) {
             to_remove.emplace(hap_ids.at(j));
         }
     }
-    if (n_equivalent!=0) cerr << "Removed " << to_string(n_equivalent) << " globally-equivalent haplotypes (out of " << to_string(n_haps) << " total)\n";
+    // if (n_equivalent!=0) cerr << "Removed " << to_string(n_equivalent) << " globally-equivalent haplotypes (out of " << to_string(n_haps) << " total)\n";
 
     // Removing globally-contained haps
     n_contained=0;
@@ -1314,7 +1314,7 @@ void TransMap::compress_haplotypes_global(float weight_quantum) {
         }
     }
     neighbors.clear(); weights.clear(); hap_ids.clear();
-    if (n_contained!=0) cerr << "Removed " << to_string(n_contained) << " globally-contained haplotypes (out of " << to_string(n_haps) << " total)\n";
+    // if (n_contained!=0) cerr << "Removed " << to_string(n_contained) << " globally-contained haplotypes (out of " << to_string(n_haps) << " total)\n";
 
     // Updating the transmap.
     // Remark: edge removal could be implemented much faster.
@@ -1360,7 +1360,7 @@ bool TransMap::has_large_weight(float n_weight, float d_weight) {
 void TransMap::compress_haplotypes_local(float n_weight, float d_weight, float weight_quantum) {
     const float DELTA = n_weight/d_weight;
     const int64_t N_SAMPLES = get_sample_count();
-    cerr << "compress_haplotypes_local> DELTA=" << to_string(DELTA) << '\n';
+    // cerr << "compress_haplotypes_local> DELTA=" << to_string(DELTA) << '\n';
 
     bool large_weight;
     int64_t i, j;
@@ -1447,7 +1447,7 @@ void TransMap::compress_haplotypes_local(float n_weight, float d_weight, float w
         }
         neighbors.clear(); weights.clear(); hap_ids.clear();
     });
-    if (n_dominated!=0) cerr << "Found " << to_string(n_dominated) << " locally-dominated haplotypes (" << to_string(((float)n_dominated)/N_SAMPLES) << " avg per sample)\n";
+    // if (n_dominated!=0) cerr << "Found " << to_string(n_dominated) << " locally-dominated haplotypes (" << to_string(((float)n_dominated)/N_SAMPLES) << " avg per sample)\n";
 
     // Updating the transmap.
     // Remark: edge removal could be implemented much faster.
@@ -1463,7 +1463,7 @@ void TransMap::compress_haplotypes_local(float n_weight, float d_weight, float w
         });
     }
     for (auto& pair: edges_to_remove_prime) remove_edge(pair.first,pair.second);
-    if (n_removed_edges!=0) cerr << "Removed " << to_string(n_removed_edges) << " edges to locally-dominated haplotypes\n";
+    // if (n_removed_edges!=0) cerr << "Removed " << to_string(n_removed_edges) << " edges to locally-dominated haplotypes\n";
 }
 
 
@@ -1626,7 +1626,7 @@ void TransMap::solve_easy_samples(float n_weight, float d_weight, float weight_q
             return;
         }
     });
-    if (n_one_hap_samples+n_two_hap_samples!=0) cerr << "Solved " << to_string(n_one_hap_samples) << " one-hap samples and " << to_string(n_two_hap_samples) << " two-hap samples. Removed " << to_string(edges_to_remove.size()) << " edges. Set to one " << to_string(present_haps.size()) << " haplotypes and " << to_string(present_edges.size()) << " edges.\n";
+    // if (n_one_hap_samples+n_two_hap_samples!=0) cerr << "Solved " << to_string(n_one_hap_samples) << " one-hap samples and " << to_string(n_two_hap_samples) << " two-hap samples. Removed " << to_string(edges_to_remove.size()) << " edges. Set to one " << to_string(present_haps.size()) << " haplotypes and " << to_string(present_edges.size()) << " edges.\n";
 
     // Updating the transmap.
     // Remark: edge removal could be implemented much faster.

--- a/src/TransitiveMap.cpp
+++ b/src/TransitiveMap.cpp
@@ -1,6 +1,7 @@
 #include "TransitiveMap.hpp"
 #include "gaf.hpp"
 #include <fstream>
+#include <algorithm>
 
 using std::ofstream;
 using std::tuple;
@@ -276,7 +277,7 @@ void TransMap::add_edge(const string& a, const string& b, float weight){
 }
 
 
-void TransMap::get_read_sample(const string& read_name, string& result) const{
+void TransMap::get_sample_of_read(const string& read_name, string& result) const{
     result.clear();
 
     // Using the HeteroGraph back end means that we iterate, even for a 1:1 mapping.
@@ -295,7 +296,7 @@ void TransMap::get_read_sample(const string& read_name, string& result) const{
 }
 
 
-void TransMap::get_read_sample(int64_t read_id, string& result) const{
+void TransMap::get_sample_of_read(int64_t read_id, string& result) const{
     result.clear();
 
     if (graph.get_node(read_id).type != 'R'){
@@ -319,7 +320,7 @@ void TransMap::get_read_sample(int64_t read_id, string& result) const{
 }
 
 
-int64_t TransMap::get_read_sample(int64_t read_id) const{
+int64_t TransMap::get_sample_of_read(int64_t read_id) const{
     if (graph.get_node(read_id).type != 'R'){
         throw runtime_error("ERROR: non-read ID provided for get_read_sample: " + to_string(read_id) + " " + graph.get_node(read_id).name);
     }
@@ -369,6 +370,16 @@ void TransMap::for_each_sample(const function<void(const string& name, int64_t i
     graph.for_each_neighbor_of_type(sample_node_name, 'S', [&](const HeteroNode& neighbor, int64_t id){
         f(neighbor.name, id);
     });
+}
+
+
+bool TransMap::has_sample(const string& sample_name) const {
+    const auto result = graph.get_edges(graph.name_to_id(sample_node_name));
+    for (const auto& [id_b, w]: result) {
+        const auto& node = graph.get_node(id_b);
+        if (node.type=='S' && node.name==sample_name) return true;
+    }
+    return false;
 }
 
 
@@ -428,17 +439,15 @@ void TransMap::for_each_read_of_path(int64_t path_id, const function<void(int64_
 }
 
 
-void TransMap::for_each_sample_of_read(const string& read_name, const function<void(const string& name, int64_t id)>& f) const{
-    graph.for_each_neighbor_of_type(read_name, 'S', [&](const HeteroNode& neighbor, int64_t id){
-        f(neighbor.name, id);
+void TransMap::for_each_sample_of_read(const string& read_name, const function<void(const string& name, int64_t sample_id)>& f) const{
+    graph.for_each_neighbor_of_type(read_name, 'S', [&](const HeteroNode& neighbor, int64_t sample_id){
+        f(neighbor.name, sample_id);
     });
 }
 
 
-void TransMap::for_each_sample_of_read(const int64_t& read_id, const function<void(int64_t id)>& f) const{
-    graph.for_each_neighbor_of_type(read_id, 'S', [&](int64_t id) {
-        f(id);
-    });
+void TransMap::for_each_sample_of_read(const int64_t& read_id, const function<void(int64_t sample_id)>& f) const{
+    graph.for_each_neighbor_of_type(read_id, 'S', [&](int64_t sample_id){ f(sample_id); });
 }
 
 
@@ -457,6 +466,21 @@ string TransMap::get_sample_of_read(const string& read_name) const{
             throw runtime_error("ERROR: multiple samples found for read: " + read_name);
         }
         result = neighbor.name;
+        i++;
+    });
+
+    return result;
+}
+
+
+int64_t TransMap::get_sample_of_read(int64_t read_id) const {
+    int64_t result;
+    size_t i=0;
+    for_each_sample_of_read(read_id, [&](int64_t sample_id){
+        if (i > 0){
+            throw runtime_error("ERROR: multiple samples found for read: " + to_string(read_id));
+        }
+        result = sample_id;
         i++;
     });
 
@@ -633,7 +657,6 @@ void TransMap::write_edge_info_to_csv(path output_path, const VariantGraph& vari
     });
 }
 
-
 void TransMap::extract_sample_as_transmap(const string& sample_name, TransMap& result) {
     result.add_sample(sample_name);
 
@@ -664,7 +687,7 @@ void TransMap::detangle_sample_paths(unordered_map<string,string>& hapmap){
 
         // Find the reads that connect to this path and group them by sample. Each sample will get their own path.
         for_each_read_of_path(path_id, [&](int64_t read_id) {
-            auto sample_id = get_read_sample(read_id);
+            auto sample_id = get_sample_of_read(read_id);
             sample_reads_of_path[sample_id].push_back(read_id);
         });
 
@@ -761,136 +784,898 @@ bool operator==(const TransMap& a, const TransMap& b) {
 }
 
 
-/**
- * Currently implemented as a quadratic scan, probably too slow for large cohorts.
- */
-void TransMap::compress(float weight_quantum, uint64_t mode) {
-    const int64_t n_reads = get_read_count();
-    const int64_t n_samples = get_sample_count();
+pair<int64_t,int64_t> TransMap::get_n_paths_of_read(int64_t read_id) const {
+    int64_t n_paths = 0;
+    int64_t last_path = -1;
+    for_each_path_of_read(read_id, [&](int64_t path_id) { n_paths++; last_path=path_id; });
+    return std::make_pair(n_paths,last_path);
+}
 
+
+bool TransMap::are_edges_distinct() const {
+    return graph.are_edges_distinct();
+}
+
+
+void TransMap::sort_adjacency_lists() {
+    graph.sort_adjacency_lists();
+}
+
+
+void TransMap::update_first_of_type() {
+    graph.update_first_of_type();
+}
+
+
+void TransMap::partition(vector<TransMap>& maps) {
+    size_t i;
+    size_t set_size;
+    int64_t id, type, component_id;
+    string sample_name, s_name;
+    vector<int64_t> stack, component_size;
+    unordered_set<int64_t> set;
+    unordered_map<int64_t, int64_t> read_component, path_component;
+
+    graph.update_first_of_type();
+
+    // Computing connected components and building the corresponding transmaps
+    maps.clear();
+    component_id=-1;
+    for_each_read([&](const string& read_name, int64_t read_id) {
+        if (read_component.contains((read_id))) return;
+        read_component.emplace(read_id,++component_id);
+        maps.emplace_back();
+        TransMap& new_map = maps.back();
+        new_map.add_read(read_name);
+        sample_name=get_sample_of_read(read_name);
+        new_map.add_sample(sample_name);
+        new_map.add_edge(read_name,sample_name);
+        stack.clear(); stack.emplace_back(read_id); stack.emplace_back(0);
+        while (!stack.empty()) {
+            type=stack.at(stack.size()-1); stack.pop_back();
+            id=stack.at(stack.size()-1); stack.pop_back();
+            if (type==0) {
+                const string& r_name = graph.get_node(id).name;
+                for_each_path_of_read(id, [&](int64_t p_id) {
+                    if (path_component.contains(p_id)) return;
+                    path_component.emplace(p_id,component_id);
+                    stack.emplace_back(p_id); stack.emplace_back(1);
+                    const string& p_name = graph.get_node(p_id).name;
+                    new_map.add_path(p_name);
+                    new_map.add_edge(r_name,p_name,try_get_edge_weight(id,p_id).second);
+                });
+            }
+            else {
+                const string& p_name = graph.get_node(id).name;
+                for_each_read_of_path(id, [&](int64_t r_id) {
+                    if (read_component.contains(r_id)) return;
+                    read_component.emplace(r_id,component_id);
+                    stack.emplace_back(r_id); stack.emplace_back(0);
+                    const string& r_name = graph.get_node(r_id).name;
+                    new_map.add_read(r_name);
+                    new_map.add_edge(r_name,p_name,try_get_edge_weight(id,r_id).second);
+                    s_name=get_sample_of_read(r_name);
+                    if (!new_map.has_sample(s_name)) new_map.add_sample(s_name);
+                    new_map.add_edge(s_name,r_name);
+                });
+            }
+        }
+        component_size.emplace_back(new_map.get_read_count());
+        component_size.emplace_back(new_map.get_path_count());
+        component_size.emplace_back(new_map.get_sample_count());
+        component_size.emplace_back(new_map.get_n_edges());
+    });
+    cerr << "Number of connected components: " << to_string(component_id+1) << '\n';
+    cerr << "Component \t n_reads \t n_paths \t n_samples \t n_edges\n";
+    for (i=0; i<component_size.size(); i+=4) cerr << to_string(i/4) << '\t' << to_string(component_size.at(i)) << '\t' << to_string(component_size.at(i+1)) << '\t' << to_string(component_size.at(i+2)) << '\t' << to_string(component_size.at(i+3)) << '\n';
+
+    // Collecting samples assigned to 2 components
+    partitioned_samples.clear();
+    for_each_sample([&](const string& sample_name, int64_t sample_id) {
+        set.clear();
+        for_each_read_of_sample(sample_name, [&](const string& read_name, int64_t read_id) {
+            set.emplace(read_component.at(read_id));
+        });
+        set_size=set.size();
+        if (set_size>2) throw runtime_error("ERROR: the reads of sample "+sample_name+" were partitioned into "+to_string(set.size())+" connected components");
+        else if (set_size==2) partitioned_samples.emplace_back(sample_name);
+    });
+    cerr << "Number of samples assigned to 2 components: " << to_string(partitioned_samples.size()) << '\n';
+}
+
+
+TransMap TransMap::partition_get_test_transmap() {
+    TransMap out;
+    out.add_sample("sample1");
+    out.add_read("s1r1"); out.add_read("s1r2"); out.add_read("s1r3");
+    out.add_edge("sample1","s1r1"); out.add_edge("sample1","s1r2"); out.add_edge("sample1","s1r3");
+    out.add_sample("sample2");
+    out.add_read("s2r1"); out.add_read("s2r2"); out.add_read("s2r3");
+    out.add_edge("sample2","s2r1"); out.add_edge("sample2","s2r2"); out.add_edge("sample2","s2r3");
+    out.add_sample("sample3");
+    out.add_read("s3r1"); out.add_read("s3r2"); out.add_read("s3r3");
+    out.add_edge("sample3","s3r1"); out.add_edge("sample3","s3r2"); out.add_edge("sample3","s3r3");
+
+    out.add_path("path1"); out.add_path("path2"); out.add_path("path3"); out.add_path("path4");
+    out.add_edge("s1r1","path1");
+    out.add_edge("s1r2","path2");
+    out.add_edge("s1r3","path3");
+
+    out.add_edge("s2r1","path2");
+    out.add_edge("s2r2","path3");
+    out.add_edge("s2r3","path3");
+
+    out.add_edge("s3r1","path1");
+    out.add_edge("s3r2","path4");
+    out.add_edge("s3r3","path4");
+    return out;
+}
+
+
+void TransMap::compress_reads(float weight_quantum, bool verbose) {
     size_t length;
     int64_t i, j, k;
-    int64_t read_id, n_clusters;
-    vector<bool> is_redundant;
-    vector<int64_t> node_ids, cluster_representative, cluster_size;
-    vector<string> sample_names;
-    vector<vector<int64_t>> neighbors, compared_weights;
-    vector<vector<float>> weights;
+    int64_t read_id, n_clusters, n_reads;
+    vector<bool> is_redundant, is_representative;
+    vector<int64_t> node_ids, cluster_representative, cluster_size, sample_ids;
+    vector<vector<int64_t>> neighbors;
+    vector<vector<float>> weights, compared_weights;
 
-    // Making sure that the neighbors of all nodes lie in the same global order
-    graph.sort_adjacency_lists();
+    graph.update_first_of_type();
 
-    // Collecting all read-haplotype edges
+    // Collecting all read-haplotype edges, with reads grouped by sample.
+    n_reads=get_n_reads();
     neighbors.reserve(n_reads);
     for (i=0; i<n_reads; i++) neighbors.emplace_back();
     weights.reserve(n_reads);
     for (i=0; i<n_reads; i++) weights.emplace_back();
-    if (weight_quantum!=0) {
-        compared_weights.reserve(n_reads);
-        for (i=0; i<n_reads; i++) compared_weights.emplace_back();
-    }
-    node_ids.reserve(n_reads);
+    compared_weights.reserve(n_reads);
+    for (i=0; i<n_reads; i++) compared_weights.emplace_back();
+    node_ids.reserve(n_reads); sample_ids.reserve(n_reads);
     i=-1;
-    for_each_read([&](const string& name, int64_t read_id) {
-        // The order in which reads are enumerated is not important
-        node_ids.emplace_back(read_id);
-        i++;
-        graph.for_each_neighbor_of_type(read_id,'P',[&](int64_t path_id) {
-            // For every read, its neighbors lie in the same global order.
-            auto [success, weight] = try_get_edge_weight(read_id, path_id);
-            neighbors.at(i).emplace_back(path_id);
-            weights.at(i).emplace_back(weight);
-            if (weight_quantum!=0) compared_weights.at(i).emplace_back((int64_t)floor(weight/weight_quantum));
-        });
-    });
-
-    // Clustering reads; adding sample-read edges; removing redundant reads; computing new read-hap weights.
-    is_redundant.reserve(n_reads);
-    for (i=0; i<n_reads; i++) is_redundant.at(i)=false;
-    if (mode==3) {
-        cluster_size.reserve(n_reads);
-        for (i=0; i<n_reads; i++) cluster_size.at(i)=0;
-    }
-    n_clusters=0;
-    for (i=0; i<n_reads; i++) {
-        if (is_redundant.at(i)) continue;
-        n_clusters++;
-        if (mode==3) cluster_size.at(i)=1;
-        read_id=node_ids.at(i); length=neighbors.at(i).size();
-        for (j=i+1; j<n_reads; j++) {
-            if (is_redundant.at(j) || neighbors.at(j)!=neighbors.at(i) || (weight_quantum==0 && weights.at(j)!=weights.at(i)) || (weight_quantum!=0 && compared_weights.at(j)!=compared_weights.at(i))) continue;
-            is_redundant.at(j)=true;
-            if (mode==3) cluster_size.at(i)++;
-            for (k=0; k<length; k++) {
-                switch (mode) {
-                    case 0: weights.at(i).at(k)=std::max(weights.at(i).at(k),weights.at(j).at(k)); break;
-                    case 1: weights.at(i).at(k)=std::min(weights.at(i).at(k),weights.at(j).at(k)); break;
-                    case 2: weights.at(i).at(k)=weights.at(i).at(k)+weights.at(j).at(k); break;
-                    case 3: weights.at(i).at(k)=weights.at(i).at(k)+weights.at(j).at(k); break;
-                }
-            }
-            for_each_sample_of_read(node_ids.at(j),[&](int64_t sample_id) {
-                graph.add_edge(sample_id,read_id,0);  // Updates both sides of the edge
-            });
-            remove_node(node_ids.at(j));
-        }
-    }
-
-    // Updating read-hap weights
-    for (i=0; i<n_reads; i++) {
-        if (is_redundant.at(i)) continue;
-        if (mode==3) {
-            length=weights.at(i).size();
-            for (j=0; j<length; j++) weights.at(i).at(j)/=cluster_size.at(i);
-        }
-        read_id=node_ids.at(i);
-        j=-1;
-        graph.for_each_neighbor_of_type(read_id,'P',[&](int64_t path_id) {
-            graph.update_edge_weight(read_id,path_id,weights.at(i).at(++j));
-        });
-    }
-    neighbors.clear(); weights.clear(); compared_weights.clear(); is_redundant.clear(); cluster_size.clear(); node_ids.clear();
-
-    // Making sure that the neighbors of all nodes lie in the same global order after read compression
-    graph.sort_adjacency_lists();
-
-    // Collecting all sample-compressedRead edges
-    sample_names.reserve(n_samples); node_ids.reserve(n_samples); neighbors.reserve(n_samples);
-    i=-1;
-    for_each_sample([&](string sample_name, int64_t sample_id) {
-        i++; sample_names.emplace_back(sample_name); node_ids.emplace_back(sample_id); neighbors.emplace_back();
+    for_each_sample([&](const string &sample_name, int64_t sample_id) {
+        if (solved_samples.contains(sample_id)) return;
         for_each_read_of_sample(sample_id, [&](int64_t read_id) {
-            // For every sample, its compressed read neighbors lie in the same global order.
-            neighbors.at(i).emplace_back(read_id);
+            node_ids.emplace_back(read_id);
+            sample_ids.emplace_back(sample_id);
+            i++;
+            graph.for_each_neighbor_of_type(read_id, 'P', [&](int64_t path_id) {
+                // For each read, its neighbors lie in the same global order.
+                auto [success, weight] = try_get_edge_weight(read_id, path_id);
+                neighbors.at(i).emplace_back(path_id);
+                weights.at(i).emplace_back(weight);
+                compared_weights.at(i).emplace_back(get_edge_weight(weight,weight_quantum));
+            });
         });
     });
-
-    // Removing redundant samples
-    sample_to_compressed_sample.clear();
-    is_redundant.reserve(n_samples);
-    for (i=0; i<n_samples; i++) is_redundant.at(i)=false;
-    n_clusters=0;
-    for (i=0; i<n_samples; i++) {
-        if (is_redundant.at(i)) continue;
-        n_clusters++;
-        for (j=i+1; j<n_samples; j++) {
-            if (is_redundant.at(j) || neighbors.at(j)!=neighbors.at(i)) continue;
-            is_redundant.at(j)=true;
-            sample_to_compressed_sample.emplace(sample_names.at(j),sample_names.at(i));
-            remove_node(node_ids.at(j));
+    n_reads=i+1;
+    if (verbose) {
+        cerr << "Read-hap weights before compression: \n";
+        for (i=0; i<n_reads; i++) {
+            read_id=node_ids.at(i);
+            cerr << "read=" << to_string(read_id) << " weights=";
+            for (j=0; j<weights.at(i).size(); j++) cerr << "(" << to_string(neighbors.at(i).at(j)) << "," << to_string(weights.at(i).at(j)) << "), ";
+            cerr << '\n';
         }
     }
-    neighbors.clear(); is_redundant.clear(); node_ids.clear();
+
+    // Clustering reads; removing redundant reads; computing new read-hap weights.
+    is_redundant.reserve(n_reads);
+    for (i=0; i<n_reads; i++) is_redundant.emplace_back(false);
+    is_representative.reserve(n_reads);
+    for (i=0; i<n_reads; i++) is_representative.emplace_back(false);
+    cluster_size.reserve(n_reads);
+    for (i=0; i<n_reads; i++) cluster_size.emplace_back(0);
+    n_clusters=0;
+    for (i=0; i<n_reads; i++) {
+        if (is_redundant.at(i)) continue;
+        n_clusters++;
+        cluster_size.at(i)=1;
+        read_id=node_ids.at(i);
+        length=neighbors.at(i).size();
+        for (j=i+1; j<n_reads; j++) {
+            if (sample_ids.at(j)!=sample_ids.at(i)) break;
+            if (is_redundant.at(j) || neighbors.at(j)!=neighbors.at(i) || compared_weights.at(j)!=compared_weights.at(i)) continue;
+            is_redundant.at(j)=true; is_representative.at(i)=true;
+            cluster_size.at(i)++;
+            for (k=0; k<length; k++) weights.at(i).at(k)+=weights.at(j).at(k);
+        }
+    }
+    compared_weights.clear();
+    cerr << "n_reads=" << to_string(n_reads) << " -> n_read_clusters=" << to_string(n_clusters) <<  " (after compressing reads)\n";
+    if (verbose) {
+        cerr << "Read-hap weights after compression: \n";
+        for (i=0; i<n_reads; i++) {
+            read_id=node_ids.at(i);
+            cerr << "read=" << to_string(read_id) << " weights=";
+            for (j=0; j<weights.at(i).size(); j++) cerr << "(" << to_string(neighbors.at(i).at(j)) << "," << to_string(weights.at(i).at(j)) << "), ";
+            cerr << '\n';
+        }
+    }
+
+    // Updating the transmap.
+    // Remark: edge removal could be implemented much faster.
+    for (i=0; i<n_reads; i++) {
+        if (is_redundant.at(i) || !is_representative.at(i)) continue;
+        read_id=node_ids.at(i); length=neighbors.at(i).size();
+        for (j=0; j<length; j++) graph.update_edge_weight(read_id, neighbors.at(i).at(j), weights.at(i).at(j));
+    }
+    for (i=0; i<n_reads; i++) {
+        if (is_redundant.at(i)) remove_node(node_ids.at(i));
+    }
 }
 
 
-void TransMap::decompress_samples() {
-    for (auto& pair: sample_to_compressed_sample) {
-        for_each_read_of_sample(pair.second, [&](const string& read_name, int64_t read_id) {
-            add_edge(pair.first,read_name,0);  // Updates both sides of the edge
+/**
+ * Implemented as a quadratic scan over all the reads in the cohort. Might be too slow for large cohorts.
+ */
+void TransMap::compress_samples(float weight_quantum) {
+    bool contained, trivial;
+    size_t length;
+    int64_t i, j, k;
+    int64_t read_id, sample_id, s_id, next_i, next_j, n_clusters, n_reads;
+    int64_t contained_first, contained_last, container_id, container_first, container_last;
+    vector<bool> used;
+    vector<int64_t> sample_ids, to_remove, cluster_size, cluster_size_prime;
+    vector<vector<int64_t>> neighbors;
+    vector<vector<float>> weights, compared_weights;
+    unordered_map<int64_t,tuple<int64_t,int64_t,int64_t,int64_t,int64_t>> sample_to_identical_sample, sample_to_container_sample;
+
+    graph.update_first_of_type();
+
+    // Collecting all read-haplotype edges, with reads grouped by unsolved sample.
+    n_reads=get_read_count();
+    neighbors.reserve(n_reads);
+    for (i=0; i<n_reads; i++) neighbors.emplace_back();
+    weights.reserve(n_reads);
+    for (i=0; i<n_reads; i++) weights.emplace_back();
+    compared_weights.reserve(n_reads);
+    for (i=0; i<n_reads; i++) compared_weights.emplace_back();
+    read_ids.clear(); read_ids.reserve(n_reads); sample_ids.reserve(n_reads);
+    i=-1;
+    for_each_sample([&](const string& sample_name, int64_t sample_id) {
+        if (solved_samples.contains(sample_id)) return;
+        for_each_read_of_sample(sample_id, [&](int64_t read_id) {
+            read_ids.emplace_back(read_id); sample_ids.emplace_back(get_id(sample_name));
+            i++;
+            graph.for_each_neighbor_of_type(read_id, 'P', [&](int64_t path_id) {
+                // For each read, its neighbors lie in the same global order.
+                auto [success, weight] = try_get_edge_weight(read_id,path_id);
+                neighbors.at(i).emplace_back(path_id);
+                weights.at(i).emplace_back(weight);
+                compared_weights.at(i).emplace_back(get_edge_weight(weight,weight_quantum));
+            });
+        });
+    });
+    n_reads=i+1;
+
+    // Finding equivalent reads across all unsolved samples
+    cluster_ids.clear(); cluster_ids.reserve(n_reads);
+    for (i=0; i<n_reads; i++) cluster_ids.emplace_back(0);
+    n_clusters=0;
+    for (i=0; i<n_reads; i++) {
+        if (cluster_ids.at(i)!=0) continue;
+        n_clusters++;
+        cluster_ids.at(i)=n_clusters;
+        read_id=read_ids.at(i);
+        for (j=i+1; j<n_reads; j++) {
+            if (cluster_ids.at(j)!=0 || neighbors.at(j)!=neighbors.at(i) || compared_weights.at(j)!=compared_weights.at(i)) continue;
+            cluster_ids.at(j)=n_clusters;
+        }
+    }
+    compared_weights.clear();
+    cerr << "n_reads=" << to_string(n_reads) << " -> n_read_clusters=" << to_string(n_clusters) << " (across all unsolved samples)\n";
+
+    cluster_size.reserve(n_clusters);
+    for (i=0; i<n_clusters; i++) cluster_size.emplace_back(0);
+    cluster_size_prime.reserve(n_clusters);
+    for (i=0; i<n_clusters; i++) cluster_size_prime.emplace_back(0);
+
+    // Removing identical samples
+    i=0;
+    while (i<n_reads) {
+        sample_id=sample_ids.at(i);
+        next_i=i+1;
+        while (next_i<n_reads) {
+            if (sample_ids.at(next_i)!=sample_id) break;
+            next_i++;
+        }
+        if (sample_to_identical_sample.contains(sample_id)) { i=next_i; continue; }
+        for (j=0; j<n_clusters; j++) cluster_size.at(j)=0;
+        for (j=i; j<next_i; j++) cluster_size.at(cluster_ids.at(j)-1)++;
+        j=next_i;
+        while (j<n_reads) {
+            s_id=sample_ids.at(j);
+            next_j=j+1;
+            while (next_j<n_reads) {
+                if (sample_ids.at(next_j)!=s_id) break;
+                next_j++;
+            }
+            if (sample_to_identical_sample.contains(s_id)) { j=next_j; continue; }
+            for (k=0; k<n_clusters; k++) cluster_size_prime.at(k)=0;
+            for (k=j; k<next_j; k++) cluster_size_prime.at(cluster_ids.at(k)-1)++;
+            if (cluster_size_prime==cluster_size) {
+                to_remove.emplace_back(s_id);
+                for (k=j; k<next_j; k++) to_remove.emplace_back(read_ids.at(k));
+                sample_to_identical_sample.emplace(s_id,std::make_tuple(sample_id,j,next_j-1,i,next_i-1));
+            }
+            j=next_j;
+        }
+        i=next_i;
+    }
+    if (!sample_to_identical_sample.empty()) cerr << "Removed " << to_string(sample_to_identical_sample.size()) << " identical samples\n";
+
+    // Removing contained samples where every read can be assigned to only one hap
+    i=0;
+    while (i<n_reads) {
+        sample_id=sample_ids.at(i);
+        next_i=i+1;
+        while (next_i<n_reads) {
+            if (sample_ids.at(next_i)!=sample_id) break;
+            next_i++;
+        }
+        if (sample_to_identical_sample.contains(sample_id)) { i=next_i; continue; }
+        trivial=true;
+        for (j=i; j<next_i; j++) {
+            if (neighbors.at(j).size()>1) { trivial=false; break; }
+        }
+        if (!trivial) { i=next_i; continue; }
+        for (j=0; j<n_clusters; j++) cluster_size.at(j)=0;
+        for (j=i; j<next_i; j++) cluster_size.at(cluster_ids.at(j)-1)++;
+        j=next_i;
+        while (j<n_reads) {
+            s_id=sample_ids.at(j);
+            next_j=j+1;
+            while (next_j<n_reads) {
+                if (sample_ids.at(next_j)!=s_id) break;
+                next_j++;
+            }
+            if (sample_to_identical_sample.contains(s_id)) { j=next_j; continue; }
+            for (k=0; k<n_clusters; k++) cluster_size_prime.at(k)=0;
+            for (k=j; k<next_j; k++) cluster_size_prime.at(cluster_ids.at(k)-1)++;
+            contained=true;
+            for (k=0; k<n_clusters; k++) {
+                if (cluster_size.at(k)>cluster_size_prime.at(k)) { contained=false; break; }
+            }
+            if (contained) {
+                to_remove.emplace_back(sample_id);
+                for (k=i; k<next_i; k++) to_remove.emplace_back(read_ids.at(k));
+                sample_to_container_sample.emplace(sample_id,std::make_tuple(s_id,i,next_i-1,j,next_j-1));
+                break;
+            }
+            j=next_j;
+        }
+        i=next_i;
+    }
+    if (!sample_to_container_sample.empty()) cerr << "Removed " << to_string(sample_to_container_sample.size()) << " contained samples with trivial haplotypes\n";
+
+    // Preparing data structures for decompression
+    sample_to_sample.clear();
+    for (auto& pair: sample_to_identical_sample) {
+        auto& t = sample_to_identical_sample.at(pair.first);
+        container_id=std::get<0>(t);
+        contained_first=std::get<1>(t); contained_last=std::get<2>(t);
+        container_first=std::get<3>(t); container_last=std::get<4>(t);
+        while (sample_to_container_sample.contains(container_id)) {
+            t=sample_to_container_sample.at(container_id);
+            container_id=std::get<0>(sample_to_container_sample.at(container_id));
+            container_first=std::get<3>(t); container_last=std::get<4>(t);
+        }
+        sample_to_sample.emplace(get_node(pair.first).name,std::make_tuple(contained_first,contained_last,container_first,container_last));
+    }
+    for (auto& pair: sample_to_container_sample) {
+        auto& t = sample_to_container_sample.at(pair.first);
+        container_id=std::get<0>(t);
+        contained_first=std::get<1>(t); contained_last=std::get<2>(t);
+        container_first=std::get<3>(t); container_last=std::get<4>(t);
+        while (sample_to_container_sample.contains(container_id)) {
+            t=sample_to_container_sample.at(container_id);
+            container_id=std::get<0>(sample_to_container_sample.at(container_id));
+            container_first=std::get<3>(t); container_last=std::get<4>(t);
+        }
+        sample_to_sample.emplace(get_node(pair.first).name,std::make_tuple(contained_first,contained_last,container_first,container_last));
+    }
+
+    // Updating the transmap.
+    // Remark: edge removal could be implemented much faster.
+    for (auto& pair: sample_to_sample) compress_samples_update_weights(std::get<0>(pair.second),std::get<1>(pair.second),std::get<2>(pair.second),std::get<3>(pair.second),weights,used);
+    for (i=0; i<n_reads; i++) {
+        sample_id=sample_ids.at(i);
+        if (sample_to_identical_sample.contains(sample_id) || sample_to_container_sample.contains(sample_id)) continue;
+        read_id=read_ids.at(i);
+        length=neighbors.at(i).size();
+        for (j=0; j<length; j++) graph.update_edge_weight(read_id,neighbors.at(i).at(j),weights.at(i).at(j));
+    }
+    for (auto node_id: to_remove) remove_node(node_id);
+}
+
+
+void TransMap::compress_samples_update_weights(int64_t from_first, int64_t from_last, int64_t to_first, int64_t to_last, vector<vector<float>>& weights, vector<bool>& used) {
+    int64_t i, j, k;
+    int64_t cluster_id;
+
+    used.clear();
+    for (i=to_first; i<=to_last; i++) used.emplace_back(false);
+    for (i=from_first; i<=from_last; i++) {
+        cluster_id=cluster_ids.at(i);
+        for (j=to_first; j<=to_last; j++) {
+            if (used.at(j-to_first) || cluster_ids.at(j)!=cluster_id) continue;
+            used.at(j-to_first)=true;
+            for (k=0; k<weights.at(i).size(); k++) weights.at(j).at(k)+=weights.at(i).at(k);
+            break;
+        }
+    }
+}
+
+
+/**
+ * Essentially the same as `compress_samples_update_weights()`.
+ */
+void TransMap::decompress_samples(vector<bool>& used) {
+    int64_t i, j;
+    int64_t cluster_id, sample_id, from_first, from_last, to_first, to_last;
+    string sample_name;
+
+    for (auto& pair: sample_to_sample) {
+        sample_name=pair.first;
+        add_sample(sample_name);
+        sample_id=get_id(sample_name);
+        auto& t = pair.second;
+        from_first=std::get<0>(t); from_last=std::get<1>(t); to_first=std::get<2>(t); to_last=std::get<3>(t);
+        used.clear();
+        for (i=to_first; i<=to_last; i++) used.emplace_back(false);
+        for (i=from_first; i<=from_last; i++) {
+            cluster_id=cluster_ids.at(i);
+            for (j=to_first; j<=to_last; j++) {
+                if (used.at(j-to_first) || cluster_ids.at(j)!=cluster_id) continue;
+                used.at(j-to_first)=true;
+                add_edge(sample_id,read_ids.at(j),0);  // Updates both sides of the edge
+                break;
+            }
+        }
+    }
+    read_ids.clear(); cluster_ids.clear(); sample_to_sample.clear();
+}
+
+
+int64_t TransMap::get_mandatory_haplotypes() {
+    graph.update_first_of_type();
+
+    int64_t out = 0;
+    for_each_read([&](const string& read_name, int64_t read_id) {
+        auto p = get_n_paths_of_read(read_id);
+        if (p.first==1) {
+            present_haps.emplace(p.second);
+            present_edges.emplace(read_id,p.second);
+            out++;
+        }
+    });
+    return out;
+}
+
+
+void TransMap::compress_haplotypes_global(float weight_quantum) {
+    const int64_t n_samples = get_sample_count();
+    int64_t n_haps = get_path_count();
+
+    int64_t i, j;
+    int64_t n_equivalent, n_contained, hap_id;
+    vector<bool> removed;
+    vector<int64_t> hap_ids;
+    unordered_set<int64_t> to_remove;
+    vector<vector<int64_t>> neighbors;
+    vector<vector<float>> weights;
+    unordered_map<int64_t,unordered_set<int64_t>> edges_to_remove;
+
+    graph.update_first_of_type();
+
+    // Collecting all haplotype-read edges
+    neighbors.reserve(n_haps);
+    for (i=0; i<n_haps; i++) neighbors.emplace_back();
+    weights.reserve(n_haps);
+    for (i=0; i<n_haps; i++) weights.emplace_back();
+    hap_ids.clear(); hap_ids.reserve(n_haps);
+    i=-1;
+    for_each_path([&](const string& path_name, int64_t path_id) {
+        hap_ids.emplace_back(path_id);
+        i++;
+        for_each_read_of_path(path_id, [&](int64_t read_id) {
+            // For each hap, its neighbors lie in the same global order.
+            auto [success, weight] = try_get_edge_weight(read_id,path_id);
+            neighbors.at(i).emplace_back(read_id);
+            weights.at(i).emplace_back(get_edge_weight(weight,weight_quantum));
+        });
+    });
+
+    // Removing globally-equivalent haps
+    n_equivalent=0;
+    removed.clear(); removed.reserve(n_haps);
+    for (i=0; i<n_haps; i++) removed.emplace_back(false);
+    for (i=0; i<n_haps; i++) {
+        if (removed.at(i)) continue;
+        for (j=i+1; j<n_haps; j++) {
+            if (removed.at(j) || neighbors.at(j)!=neighbors.at(i) || weights.at(j)!=weights.at(i)) continue;
+            n_equivalent++;
+            removed.at(j)=true;
+            to_remove.emplace(hap_ids.at(j));
+        }
+    }
+    if (n_equivalent!=0) cerr << "Removed " << to_string(n_equivalent) << " globally-equivalent haplotypes (out of " << to_string(n_haps) << " total)\n";
+
+    // Removing globally-contained haps
+    n_contained=0;
+    for (i=0; i<n_haps; i++) {
+        if (removed.at(i)) continue;
+        for (j=i+1; j<n_haps; j++) {
+            if (removed.at(j)) continue;
+            if (is_haplotype_contained(i,j,neighbors,weights)) {
+                n_contained++;
+                removed.at(i)=true;
+                to_remove.emplace(hap_ids.at(i));
+                break;
+            }
+        }
+    }
+    neighbors.clear(); weights.clear(); hap_ids.clear();
+    if (n_contained!=0) cerr << "Removed " << to_string(n_contained) << " globally-contained haplotypes (out of " << to_string(n_haps) << " total)\n";
+
+    // Updating the transmap.
+    // Remark: edge removal could be implemented much faster.
+    for (auto node_id: to_remove) remove_node(node_id);
+}
+
+
+bool TransMap::is_haplotype_contained(int64_t from, int64_t to, const vector<vector<int64_t>>& neighbors, const vector<vector<float>>& weights) {
+    const size_t length_from = neighbors.at(from).size();
+    const size_t length_to = neighbors.at(to).size();
+    if (length_from>length_to) return false;
+
+    bool found;
+    size_t i, j;
+    int64_t neighbor_from, neighbor_to;
+
+    j=0;
+    for (i=0; i<length_from; i++) {
+        neighbor_from=neighbors.at(from).at(i);
+        found=false;
+        while (j<length_to) {
+            neighbor_to=neighbors.at(to).at(j);
+            if (neighbor_to>neighbor_from) break;
+            else if (neighbor_to<neighbor_from) j++;
+            else {
+                found=true;
+                if (weights.at(to).at(j)>weights.at(from).at(i)) return false;
+                break;
+            }
+        }
+        if (!found) return false;
+    }
+    return true;
+}
+
+
+bool TransMap::has_large_weight(float n_weight, float d_weight) {
+    const float DELTA = n_weight/d_weight;
+    return graph.has_large_weight(get_id(read_node_name),'P',DELTA);
+}
+
+
+void TransMap::compress_haplotypes_local(float n_weight, float d_weight, float weight_quantum) {
+    const float DELTA = n_weight/d_weight;
+    const int64_t N_SAMPLES = get_sample_count();
+    cerr << "compress_haplotypes_local> DELTA=" << to_string(DELTA) << '\n';
+
+    bool large_weight;
+    int64_t i, j;
+    int64_t n_dominated, hap_id, n_removed_edges, n_reads, read_id;
+    float weight;
+    size_t length, n_haps;
+    vector<bool> removed;
+    vector<int64_t> hap_ids, read_ids, tmp_vector;
+    vector<pair<int64_t,int64_t>> edges_to_remove_prime;
+    unordered_set<int64_t> to_remove;
+    vector<vector<int64_t>> neighbors, neighbors_prime;
+    vector<vector<float>> weights, weights_prime;
+    unordered_map<int64_t,unordered_set<int64_t>> edges_to_remove;
+
+    graph.update_first_of_type();
+
+    // Removing locally-dominated haps
+    n_dominated=0;
+    for_each_sample([&](const string& sample_name, int64_t sample_id) {
+        // Building the read-hap matrix
+        read_ids.clear(); neighbors_prime.clear(); weights_prime.clear();
+        i=-1; large_weight=false;
+        for_each_read_of_sample(sample_id, [&](int64_t read_id) {
+            // Reads are assumed to be enumerated in sorted order by ID.
+            i++; read_ids.emplace_back(read_id);
+            neighbors_prime.emplace_back(); weights_prime.emplace_back();
+            for_each_path_of_read(read_id, [&](int64_t path_id) {
+                // Haps are assumed to be enumerated in sorted order by ID.
+                auto [success, w] = try_get_edge_weight(read_id,path_id);
+                neighbors_prime.at(i).emplace_back(path_id);
+                w=get_edge_weight(w,weight_quantum);
+                weights_prime.at(i).emplace_back(w);
+                if (w>=DELTA) large_weight=true;
+            });
+        });
+        n_reads=i+1;
+        if (n_reads==0 || !large_weight) return;
+        // Building the hap-read matrix
+        tmp_vector.clear();
+        for (i=0; i<n_reads; i++) tmp_vector.insert(tmp_vector.end(),neighbors_prime.at(i).begin(),neighbors_prime.at(i).end());
+        length=tmp_vector.size();
+        if (length==0) return;
+        if (length>1) std::sort(tmp_vector.begin(),tmp_vector.end());
+        hap_ids.clear(); hap_ids.emplace_back(tmp_vector.at(0));
+        for (i=1; i<tmp_vector.size(); i++) {
+            if (tmp_vector.at(i)!=tmp_vector.at(i-1)) hap_ids.emplace_back(tmp_vector.at(i));
+        }
+        n_haps=hap_ids.size();
+        neighbors.clear(); weights.clear();
+        for (i=0; i<n_haps; i++) neighbors.emplace_back();
+        for (i=0; i<n_haps; i++) weights.emplace_back();
+        for (i=0; i<n_reads; i++) {
+            read_id=read_ids.at(i);
+            length=neighbors_prime.at(i).size();
+            for (j=0; j<length; j++) {
+                hap_id=neighbors_prime.at(i).at(j);
+                weight=weights_prime.at(i).at(j);
+                auto p = std::lower_bound(hap_ids.begin(),hap_ids.end(),hap_id);  // Could have been implemented as a mergesort since both arrays are sorted
+                neighbors.at(p-hap_ids.begin()).emplace_back(read_id);
+                weights.at(p-hap_ids.begin()).emplace_back(weight);
+            }
+        }
+        neighbors_prime.clear(); weights_prime.clear(); read_ids.clear();
+        // Removing dominated haps
+        removed.clear();
+        for (i=0; i<n_haps; i++) removed.emplace_back(false);
+        for (i=0; i<n_haps; i++) {
+            if (removed.at(i)) continue;
+            for (j=i+1; j<n_haps; j++) {
+                if (removed.at(j)) continue;
+                if (is_haplotype_dominated(DELTA,i,j,neighbors,weights)) {
+                    n_dominated++;
+                    removed.at(i)=true;
+                    hap_id=hap_ids.at(i);
+                    if (edges_to_remove.contains(hap_id)) edges_to_remove.at(hap_id).emplace(sample_id);
+                    else {
+                        unordered_set<int64_t> v;
+                        v.emplace(sample_id);
+                        edges_to_remove.emplace(hap_id,v);
+                    }
+                    break;
+                }
+            }
+        }
+        neighbors.clear(); weights.clear(); hap_ids.clear();
+    });
+    if (n_dominated!=0) cerr << "Found " << to_string(n_dominated) << " locally-dominated haplotypes (" << to_string(((float)n_dominated)/N_SAMPLES) << " avg per sample)\n";
+
+    // Updating the transmap.
+    // Remark: edge removal could be implemented much faster.
+    edges_to_remove_prime.clear();
+    n_removed_edges=0;
+    for (auto& pair: edges_to_remove) {
+        hap_id=pair.first;
+        for_each_read_of_path(hap_id, [&](int64_t read_id) {
+            if (pair.second.contains(get_sample_of_read(read_id))) {
+                edges_to_remove_prime.emplace_back(read_id,hap_id);
+                n_removed_edges++;
+            }
         });
     }
-    sample_to_compressed_sample.clear();
+    for (auto& pair: edges_to_remove_prime) remove_edge(pair.first,pair.second);
+    if (n_removed_edges!=0) cerr << "Removed " << to_string(n_removed_edges) << " edges to locally-dominated haplotypes\n";
+}
+
+
+bool TransMap::is_haplotype_dominated(float delta, int64_t from, int64_t to, const vector<vector<int64_t>>& neighbors, const vector<vector<float>>& weights) {
+    const size_t length_from = neighbors.at(from).size();
+    const size_t length_to = neighbors.at(to).size();
+    if (length_from>length_to) return false;
+
+    bool found;
+    size_t i, j;
+    int64_t neighbor_from, neighbor_to;
+
+    j=0;
+    for (i=0; i<length_from; i++) {
+        neighbor_from=neighbors.at(from).at(i);
+        found=false;
+        while (j<length_to) {
+            neighbor_to=neighbors.at(to).at(j);
+            if (neighbor_to>neighbor_from) break;
+            else if (neighbor_to<neighbor_from) j++;
+            else {
+                found=true;
+                if (weights.at(to).at(j)>weights.at(from).at(i)-delta) return false;
+                break;
+            }
+        }
+        if (!found) return false;
+    }
+    return true;
+}
+
+
+void TransMap::solve_easy_samples(float n_weight, float d_weight, float weight_quantum) {
+    const float DELTA = n_weight/d_weight;
+    const int64_t N_HAPS = get_path_count();
+
+    bool large_weight, not_worse, favored;
+    int64_t i, j, k;
+    int64_t read_id, hap_id, min_hap_id, n_reads, hap1, hap2, n_one_hap_samples, n_two_hap_samples;
+    size_t n_haps;
+    float weight, min_weight;
+    vector<int64_t> read_ids;
+    unordered_set<int64_t> tmp_set;
+    vector<vector<int64_t>> neighbors;
+    vector<vector<float>> weights;
+    vector<pair<int64_t,int64_t>> edges_to_remove;
+    unordered_set<int64_t> favored_haps;
+    unordered_map<int64_t,unordered_set<int64_t>> hap_to_reads;
+
+    graph.update_first_of_type();
+
+    // Solving easy samples
+    solved_samples.clear();
+    n_one_hap_samples=0; n_two_hap_samples=0;
+    edges_to_remove.clear();
+    hap_to_reads.reserve(N_HAPS); favored_haps.reserve(N_HAPS); tmp_set.reserve(N_HAPS);
+    for_each_sample([&](const string& sample_name, int64_t sample_id) {
+        read_ids.clear(); neighbors.clear(); weights.clear();
+        i=-1; large_weight=false;
+        for_each_read_of_sample(sample_id, [&](int64_t read_id) {
+            i++; read_ids.emplace_back(read_id);
+            neighbors.emplace_back(); weights.emplace_back();
+            for_each_path_of_read(read_id, [&](int64_t path_id) {
+                // For each read, its neighbors lie in the same global order.
+                auto [success, w] = try_get_edge_weight(read_id,path_id);
+                neighbors.at(i).emplace_back(path_id);
+                w=get_edge_weight(w,weight_quantum);
+                weights.at(i).emplace_back(w);
+                if (w>=DELTA) large_weight=true;
+            });
+        });
+        n_reads=read_ids.size();
+        if (n_reads==0 || !large_weight) return;
+        hap_to_reads.clear(); favored_haps.clear();
+        for (i=0; i<n_reads; i++) {
+            read_id=read_ids.at(i);
+            n_haps=neighbors.at(i).size();
+            for (j=0; j<n_haps; j++) {
+                hap_id=neighbors.at(i).at(j);
+                weight=weights.at(i).at(j);
+                not_worse=true;
+                for (k=0; k<n_haps; k++) {
+                    if (k!=j && weight>weights.at(i).at(k)) { not_worse=false; break; }
+                }
+                if (not_worse) {
+                    if (hap_to_reads.contains(hap_id)) hap_to_reads.at(hap_id).insert(read_id);
+                    else {
+                        unordered_set<int64_t> new_set;
+                        new_set.insert(read_id);
+                        hap_to_reads[hap_id]=new_set;
+                    }
+                    favored=true;
+                    for (k=0; k<n_haps; k++) {
+                        if (k!=j && weight>weights.at(i).at(k)-DELTA) { favored=false; break; }
+                    }
+                    if (favored) favored_haps.insert(hap_id);
+                }
+            }
+        }
+        // One-hap sample
+        hap1=-1;
+        for (auto& hap_id: favored_haps) {
+            if (hap_to_reads.at(hap_id).size()==n_reads) { hap1=hap_id; break; }
+        }
+        if (hap1!=-1) {
+            for (i=0; i<n_reads; i++) {
+                read_id=read_ids.at(i);
+                n_haps=neighbors.at(i).size();
+                for (j=0; j<n_haps; j++) {
+                    hap_id=neighbors.at(i).at(j);
+                    if (hap_id!=hap1) edges_to_remove.emplace_back(read_id,hap_id);
+                    else present_edges.emplace(read_id,hap_id);
+                }
+            }
+            present_haps.emplace(hap1);
+            solved_samples.insert(sample_id);
+            n_one_hap_samples++;
+            return;
+        }
+        // Two-hap sample
+        hap1=-1; hap2=-1;
+        for (auto& hap_id: favored_haps) {
+            for (auto& hap_id_prime: favored_haps) {
+                if (hap_id_prime==hap_id) continue;
+                tmp_set.clear();
+                for (auto& element: hap_to_reads.at(hap_id)) tmp_set.emplace(element);
+                for (auto& element: hap_to_reads.at(hap_id_prime)) tmp_set.emplace(element);
+                if (tmp_set.size()!=n_reads) continue;
+                hap1=hap_id; hap2=hap_id_prime;
+                break;
+            }
+            if (hap1!=-1 && hap2!=-1) break;
+        }
+        if (hap1!=-1 && hap2!=-1) {
+            for (i=0; i<n_reads; i++) {
+                read_id=read_ids.at(i);
+                min_hap_id=-1; min_weight=INT32_MAX;
+                n_haps=neighbors.at(i).size();
+                for (j=0; j<n_haps; j++) {
+                    hap_id=neighbors.at(i).at(j);
+                    weight=weights.at(i).at(j);
+                    if (hap_id!=hap1 && hap_id!=hap2) edges_to_remove.emplace_back(read_id,hap_id);
+                    else if (weight<min_weight) { min_weight=weight; min_hap_id=hap_id; }
+                }
+                for (j=0; j<n_haps; j++) {
+                    hap_id=neighbors.at(i).at(j);
+                    if (hap_id==hap1) {
+                        if (min_hap_id!=hap1) edges_to_remove.emplace_back(read_id,hap_id);
+                        else present_edges.emplace(read_id,hap_id);
+                    }
+                    else if (hap_id==hap2) {
+                        if (min_hap_id!=hap2) edges_to_remove.emplace_back(read_id,hap_id);
+                        else present_edges.emplace(read_id,hap_id);
+                    }
+                }
+            }
+            present_haps.emplace(hap1); present_haps.emplace(hap2);
+            solved_samples.insert(sample_id);
+            n_two_hap_samples++;
+            return;
+        }
+    });
+    if (n_one_hap_samples+n_two_hap_samples!=0) cerr << "Solved " << to_string(n_one_hap_samples) << " one-hap samples and " << to_string(n_two_hap_samples) << " two-hap samples. Removed " << to_string(edges_to_remove.size()) << " edges. Set to one " << to_string(present_haps.size()) << " haplotypes and " << to_string(present_edges.size()) << " edges.\n";
+
+    // Updating the transmap.
+    // Remark: edge removal could be implemented much faster.
+    for (auto& pair: edges_to_remove) remove_edge(pair.first,pair.second);
+}
+
+
+TransMap TransMap::solve_easy_samples_get_test_transmap(float n_weight, float d_weight) {
+    const float DELTA = n_weight/d_weight;
+    const float SMALL_WEIGHT = DELTA+1;
+    const float LARGE_WEIGHT = SMALL_WEIGHT+DELTA;
+
+    TransMap out;
+    out.add_sample("sample1");
+    out.add_read("s1r1"); out.add_read("s1r2"); out.add_read("s1r3");
+    out.add_edge("sample1","s1r1"); out.add_edge("sample1","s1r2"); out.add_edge("sample1","s1r3");
+    out.add_sample("sample2");
+    out.add_read("s2r1"); out.add_read("s2r2"); out.add_read("s2r3");
+    out.add_edge("sample2","s2r1"); out.add_edge("sample2","s2r2"); out.add_edge("sample2","s2r3");
+    out.add_sample("sample3");
+    out.add_read("s3r1"); out.add_read("s3r2"); out.add_read("s3r3");
+    out.add_edge("sample3","s3r1"); out.add_edge("sample3","s3r2"); out.add_edge("sample3","s3r3");
+
+    out.add_path("path1"); out.add_path("path2"); out.add_path("path3");
+    out.add_edge("s1r1","path1",SMALL_WEIGHT); out.add_edge("s1r1","path2",LARGE_WEIGHT); out.add_edge("s1r1","path3",LARGE_WEIGHT);
+    out.add_edge("s1r2","path1",LARGE_WEIGHT); out.add_edge("s1r2","path2",LARGE_WEIGHT); out.add_edge("s1r2","path3",LARGE_WEIGHT);
+    out.add_edge("s1r3","path1",LARGE_WEIGHT); out.add_edge("s1r3","path2",LARGE_WEIGHT); out.add_edge("s1r3","path3",LARGE_WEIGHT);
+
+    out.add_edge("s2r1","path2",SMALL_WEIGHT); out.add_edge("s2r1","path1",LARGE_WEIGHT); out.add_edge("s2r1","path3",LARGE_WEIGHT);
+    out.add_edge("s2r2","path3",SMALL_WEIGHT); out.add_edge("s2r2","path1",LARGE_WEIGHT); out.add_edge("s2r2","path2",LARGE_WEIGHT);
+    out.add_edge("s2r3","path1",LARGE_WEIGHT); out.add_edge("s2r3","path2",LARGE_WEIGHT); out.add_edge("s2r3","path3",LARGE_WEIGHT);
+
+    out.add_edge("s3r1","path1",SMALL_WEIGHT); out.add_edge("s3r1","path2",LARGE_WEIGHT); out.add_edge("s3r1","path3",LARGE_WEIGHT);
+    out.add_edge("s3r2","path1",LARGE_WEIGHT); out.add_edge("s3r2","path2",LARGE_WEIGHT); out.add_edge("s3r2","path3",LARGE_WEIGHT);
+    out.add_edge("s3r3","path2",LARGE_WEIGHT); out.add_edge("s3r3","path3",LARGE_WEIGHT);
+    return out;
+}
+
+
+float TransMap::get_edge_weight(float weight, float weight_quantum) {
+    return weight_quantum!=0?(float)(round(weight/weight_quantum)*weight_quantum):weight;
+}
+
+
+void TransMap::clear_present_haps_edges() {
+    present_haps.clear(); present_edges.clear();
 }
 
 

--- a/src/TransitiveMap.cpp
+++ b/src/TransitiveMap.cpp
@@ -1207,10 +1207,11 @@ void TransMap::compress_samples_update_weights(int64_t from_first, int64_t from_
 /**
  * Essentially the same as `compress_samples_update_weights()`.
  */
-void TransMap::decompress_samples(vector<bool>& used) {
+void TransMap::decompress_samples() {
     int64_t i, j;
     int64_t cluster_id, sample_id, from_first, from_last, to_first, to_last;
     string sample_name;
+    vector<bool> used;
 
     for (auto& pair: sample_to_sample) {
         sample_name=pair.first;

--- a/src/TransitiveMap.cpp
+++ b/src/TransitiveMap.cpp
@@ -16,10 +16,12 @@ TransMap::TransMap(){
     graph.add_node(variant_node_name, 'v');
 }
 
+
 const string TransMap::sample_node_name = "sample_node";
 const string TransMap::read_node_name = "read_node";
 const string TransMap::path_node_name = "path_node";
 const string TransMap::variant_node_name = "variant_node";
+
 
 void TransMap::reserve_nodes(size_t n){
     graph.reserve_nodes(n);
@@ -317,8 +319,6 @@ void TransMap::get_read_sample(int64_t read_id, string& result) const{
 }
 
 
-
-
 int64_t TransMap::get_read_sample(int64_t read_id) const{
     if (graph.get_node(read_id).type != 'R'){
         throw runtime_error("ERROR: non-read ID provided for get_read_sample: " + to_string(read_id) + " " + graph.get_node(read_id).name);
@@ -431,6 +431,13 @@ void TransMap::for_each_read_of_path(int64_t path_id, const function<void(int64_
 void TransMap::for_each_sample_of_read(const string& read_name, const function<void(const string& name, int64_t id)>& f) const{
     graph.for_each_neighbor_of_type(read_name, 'S', [&](const HeteroNode& neighbor, int64_t id){
         f(neighbor.name, id);
+    });
+}
+
+
+void TransMap::for_each_sample_of_read(const int64_t& read_id, const function<void(int64_t id)>& f) const{
+    graph.for_each_neighbor_of_type(read_id, 'S', [&](int64_t id) {
+        f(id);
     });
 }
 
@@ -751,6 +758,139 @@ bool operator==(const TransMap& a, const TransMap& b) {
     });
 
     return (a_nodes == b_nodes) and (a_edges == b_edges);
+}
+
+
+/**
+ * Currently implemented as a quadratic scan, probably too slow for large cohorts.
+ */
+void TransMap::compress(float weight_quantum, uint64_t mode) {
+    const int64_t n_reads = get_read_count();
+    const int64_t n_samples = get_sample_count();
+
+    size_t length;
+    int64_t i, j, k;
+    int64_t read_id, n_clusters;
+    vector<bool> is_redundant;
+    vector<int64_t> node_ids, cluster_representative, cluster_size;
+    vector<string> sample_names;
+    vector<vector<int64_t>> neighbors, compared_weights;
+    vector<vector<float>> weights;
+
+    // Making sure that the neighbors of all nodes lie in the same global order
+    graph.sort_adjacency_lists();
+
+    // Collecting all read-haplotype edges
+    neighbors.reserve(n_reads);
+    for (i=0; i<n_reads; i++) neighbors.emplace_back();
+    weights.reserve(n_reads);
+    for (i=0; i<n_reads; i++) weights.emplace_back();
+    if (weight_quantum!=0) {
+        compared_weights.reserve(n_reads);
+        for (i=0; i<n_reads; i++) compared_weights.emplace_back();
+    }
+    node_ids.reserve(n_reads);
+    i=-1;
+    for_each_read([&](const string& name, int64_t read_id) {
+        // The order in which reads are enumerated is not important
+        node_ids.emplace_back(read_id);
+        i++;
+        graph.for_each_neighbor_of_type(read_id,'P',[&](int64_t path_id) {
+            // For every read, its neighbors lie in the same global order.
+            auto [success, weight] = try_get_edge_weight(read_id, path_id);
+            neighbors.at(i).emplace_back(path_id);
+            weights.at(i).emplace_back(weight);
+            if (weight_quantum!=0) compared_weights.at(i).emplace_back((int64_t)floor(weight/weight_quantum));
+        });
+    });
+
+    // Clustering reads; adding sample-read edges; removing redundant reads; computing new read-hap weights.
+    is_redundant.reserve(n_reads);
+    for (i=0; i<n_reads; i++) is_redundant.at(i)=false;
+    if (mode==3) {
+        cluster_size.reserve(n_reads);
+        for (i=0; i<n_reads; i++) cluster_size.at(i)=0;
+    }
+    n_clusters=0;
+    for (i=0; i<n_reads; i++) {
+        if (is_redundant.at(i)) continue;
+        n_clusters++;
+        if (mode==3) cluster_size.at(i)=1;
+        read_id=node_ids.at(i); length=neighbors.at(i).size();
+        for (j=i+1; j<n_reads; j++) {
+            if (is_redundant.at(j) || neighbors.at(j)!=neighbors.at(i) || (weight_quantum==0 && weights.at(j)!=weights.at(i)) || (weight_quantum!=0 && compared_weights.at(j)!=compared_weights.at(i))) continue;
+            is_redundant.at(j)=true;
+            if (mode==3) cluster_size.at(i)++;
+            for (k=0; k<length; k++) {
+                switch (mode) {
+                    case 0: weights.at(i).at(k)=std::max(weights.at(i).at(k),weights.at(j).at(k)); break;
+                    case 1: weights.at(i).at(k)=std::min(weights.at(i).at(k),weights.at(j).at(k)); break;
+                    case 2: weights.at(i).at(k)=weights.at(i).at(k)+weights.at(j).at(k); break;
+                    case 3: weights.at(i).at(k)=weights.at(i).at(k)+weights.at(j).at(k); break;
+                }
+            }
+            for_each_sample_of_read(node_ids.at(j),[&](int64_t sample_id) {
+                graph.add_edge(sample_id,read_id,0);  // Updates both sides of the edge
+            });
+            remove_node(node_ids.at(j));
+        }
+    }
+
+    // Updating read-hap weights
+    for (i=0; i<n_reads; i++) {
+        if (is_redundant.at(i)) continue;
+        if (mode==3) {
+            length=weights.at(i).size();
+            for (j=0; j<length; j++) weights.at(i).at(j)/=cluster_size.at(i);
+        }
+        read_id=node_ids.at(i);
+        j=-1;
+        graph.for_each_neighbor_of_type(read_id,'P',[&](int64_t path_id) {
+            graph.update_edge_weight(read_id,path_id,weights.at(i).at(++j));
+        });
+    }
+    neighbors.clear(); weights.clear(); compared_weights.clear(); is_redundant.clear(); cluster_size.clear(); node_ids.clear();
+
+    // Making sure that the neighbors of all nodes lie in the same global order after read compression
+    graph.sort_adjacency_lists();
+
+    // Collecting all sample-compressedRead edges
+    sample_names.reserve(n_samples); node_ids.reserve(n_samples); neighbors.reserve(n_samples);
+    i=-1;
+    for_each_sample([&](string sample_name, int64_t sample_id) {
+        i++; sample_names.emplace_back(sample_name); node_ids.emplace_back(sample_id); neighbors.emplace_back();
+        for_each_read_of_sample(sample_id, [&](int64_t read_id) {
+            // For every sample, its compressed read neighbors lie in the same global order.
+            neighbors.at(i).emplace_back(read_id);
+        });
+    });
+
+    // Removing redundant samples
+    sample_to_compressed_sample.clear();
+    is_redundant.reserve(n_samples);
+    for (i=0; i<n_samples; i++) is_redundant.at(i)=false;
+    n_clusters=0;
+    for (i=0; i<n_samples; i++) {
+        if (is_redundant.at(i)) continue;
+        n_clusters++;
+        for (j=i+1; j<n_samples; j++) {
+            if (is_redundant.at(j) || neighbors.at(j)!=neighbors.at(i)) continue;
+            is_redundant.at(j)=true;
+            sample_to_compressed_sample.emplace(sample_names.at(j),sample_names.at(i));
+            remove_node(node_ids.at(j));
+        }
+    }
+    neighbors.clear(); is_redundant.clear(); node_ids.clear();
+}
+
+
+void TransMap::decompress_samples() {
+    for (auto& pair: sample_to_compressed_sample) {
+        for_each_read_of_sample(pair.second, [&](const string& read_name, int64_t read_id) {
+            add_edge(pair.first,read_name,0);  // Updates both sides of the edge
+        });
+    }
+    sample_to_compressed_sample.clear();
 }
 
 

--- a/src/TransitiveMap.cpp
+++ b/src/TransitiveMap.cpp
@@ -615,7 +615,7 @@ void TransMap::for_edge_in_bfs(
 }
 
 
-void TransMap::write_edge_info_to_csv(path output_path, const VariantGraph& variant_graph) const{
+void TransMap::write_edge_info_to_csv(path output_path, const VariantGraph& variant_graph, bool use_sample_id) const{
     ofstream out(output_path);
 
     // Write header
@@ -647,7 +647,13 @@ void TransMap::write_edge_info_to_csv(path output_path, const VariantGraph& vari
                     path_length += int32_t(node_length);
                 }
 
-                out << sample_name << ',' << get_node(read_id).name << ',' << read_length << ',' << get_node(path_id).name << ',' << path_length << ',' << weight << '\n';
+                string s = sample_name;
+
+                if (use_sample_id) {
+                    s = to_string(sample_id);
+                }
+
+                out << s << ',' << get_node(read_id).name << ',' << read_length << ',' << get_node(path_id).name << ',' << path_length << ',' << weight << '\n';
             });
         });
     });

--- a/src/executable/hapestry.cpp
+++ b/src/executable/hapestry.cpp
@@ -1137,7 +1137,7 @@ void merge_thread_fn(
         }
 
         if (not opt_config.skip_solve){
-            try {
+            // try {
                 TerminationReason termination_reason;
 
                 if (opt_config.samplewise) {
@@ -1151,7 +1151,13 @@ void merge_thread_fn(
                     transmap.retangle_sample_paths(hapmap);
                 }
                 else {
-                    termination_reason = optimize(transmap, opt_config, subdir, true);
+
+                    if (opt_config.use_compression) {
+                        termination_reason = optimize_compressed(transmap, opt_config, subdir, true);
+                    }
+                    else {
+                        termination_reason = optimize(transmap, opt_config, subdir, true);
+                    }
                 }
 
                 // Handle timeout case (do nothing)
@@ -1219,11 +1225,11 @@ void merge_thread_fn(
                         );
                     }
                 }
-            }
-            catch (const exception& e) {
-                cerr << e.what() << '\n';
-                cerr << "ERROR caught at " << region.to_unflanked_string(':',flank_length) << '\n';
-            }
+            // }
+            // catch (const exception& e) {
+            //     cerr << e.what() << '\n';
+            //     cerr << "ERROR caught at " << region.to_unflanked_string(':',flank_length) << '\n';
+            // }
         }
 
         if (HAPESTRY_DEBUG){

--- a/src/executable/hapestry.cpp
+++ b/src/executable/hapestry.cpp
@@ -1151,23 +1151,7 @@ void merge_thread_fn(
                     transmap.retangle_sample_paths(hapmap);
                 }
                 else {
-                    if (opt_config.use_compression) {
-                        transmap.sort_adjacency_lists();
-                        transmap.update_first_of_type();
-                        transmap.compress_haplotypes_global(0);
-                        transmap.compress_haplotypes_local(0, opt_config.d_weight, 0);
-                        transmap.solve_easy_samples(0, opt_config.d_weight, 0);
-                        transmap.compress_reads(0);
-                        transmap.compress_samples(0);
-
-                        termination_reason = optimize(transmap, opt_config, subdir, true);
-
-                        vector<bool> used;
-                        transmap.decompress_samples(used);
-                    }
-                    else {
-                        termination_reason = optimize(transmap, opt_config, subdir, true);
-                    }
+                    termination_reason = optimize(transmap, opt_config, subdir, true);
                 }
 
                 // Handle timeout case (do nothing)
@@ -1789,8 +1773,6 @@ int main (int argc, char* argv[]){
     app.add_flag("--skip_solve", optimizer_config.skip_solve, "Invoke this to skip the optimization step. CSVs for each optimization input will still be written.");
 
     app.add_flag("--rescale_weights", optimizer_config.rescale_weights, "Invoke this to use quadratic difference-from-best match rescaling for read-to-path edges.");
-
-    app.add_flag("--quadratic_objective", optimizer_config.use_quadratic_objective, "Invoke this to use quadratic objective which minimizes the square distance from the 'utopia point'. May incur large run time cost.");
 
     app.add_flag("--debug", HAPESTRY_DEBUG, "Invoke this to add more logging and output");
 

--- a/src/executable/hapestry.cpp
+++ b/src/executable/hapestry.cpp
@@ -53,6 +53,7 @@ using std::min;
 using std::cref;
 using std::ref;
 
+#include "cpptrace/from_current.hpp"
 
 using namespace sv_merge;
 
@@ -1137,7 +1138,7 @@ void merge_thread_fn(
         }
 
         if (not opt_config.skip_solve){
-            // try {
+            CPPTRACE_TRY {
                 TerminationReason termination_reason;
 
                 if (opt_config.samplewise) {
@@ -1225,11 +1226,11 @@ void merge_thread_fn(
                         );
                     }
                 }
-            // }
-            // catch (const exception& e) {
-            //     cerr << e.what() << '\n';
-            //     cerr << "ERROR caught at " << region.to_unflanked_string(':',flank_length) << '\n';
-            // }
+            } CPPTRACE_CATCH(const std::exception& e) {
+                cerr << "ERROR caught at " << region.to_unflanked_string(':',flank_length) << '\n';
+                std::cerr<<"Exception: "<<e.what()<<std::endl;
+                cpptrace::from_current_exception().print_with_snippets();
+            }
         }
 
         if (HAPESTRY_DEBUG){

--- a/src/executable/hapestry.cpp
+++ b/src/executable/hapestry.cpp
@@ -1127,7 +1127,7 @@ void merge_thread_fn(
         if (not hapestry_config.skip_nonessential_logs){
             // Write the full transmap to CSV (in the form of annotated edges) BEFORE RESCALING WEIGHTS!
             path output_csv = subdir / "reads_to_paths.csv";
-            transmap.write_edge_info_to_csv(output_csv, variant_graph);
+            transmap.write_edge_info_to_csv(output_csv, variant_graph, hapestry_config.obscure_sample_names);
         }
 
         if (opt_config.rescale_weights) {
@@ -1797,9 +1797,13 @@ int main (int argc, char* argv[]){
 
     app.add_flag("--samplewise", optimizer_config.samplewise, "Use samplewise solver instead of global solver");
 
-    app.add_flag("--compress", optimizer_config.use_compression, "Use reversible compression methods to simplify the problem before solving with LP solver");
+    app.add_flag("--compress", optimizer_config.use_compression, "Use reversible compression methods to simplify the TransMap (problem input) before solving with LP solver");
+
+    app.add_flag("--compress_quantum", optimizer_config.compress_quantum, "Constant by which to quantize the weight comparisons. By default (quantum=0) edges may have a maximum of up to 1000 different values. E.g. quantum=2, possible values = 500");
 
     app.add_flag("--prune_with_d_min", optimizer_config.prune_with_d_min, "Use d_min solution to remove all edges not used");
+
+    app.add_flag("--obscure_sample_names_from_csv", hapestry_config.obscure_sample_names, "Don't write sample names to reads_to_paths.csv. Instead, write an arbitrarily determined integer ID.");
 
     try{
         app.parse(argc, argv);

--- a/src/path_optimizer_mathopt.cpp
+++ b/src/path_optimizer_mathopt.cpp
@@ -1608,8 +1608,6 @@ TerminationReason optimize_compressed(TransMap& transmap, const OptimizerConfig&
     // For d_min step, n_weight is 0 and d_weight is 1 because n is not considered in the objective
     clone.sort_adjacency_lists();
     clone.update_first_of_type();
-    clone.get_mandatory_haplotypes();
-    clone.compress_haplotypes_global(0);
     clone.compress_haplotypes_local(0,1,0);
     clone.solve_easy_samples(0,1,0);
     clone.compress_reads(0);
@@ -1654,8 +1652,6 @@ TerminationReason optimize_compressed(TransMap& transmap, const OptimizerConfig&
     t.reset();
     clone.sort_adjacency_lists();
     clone.update_first_of_type();
-    clone.get_mandatory_haplotypes();
-    clone.compress_haplotypes_global(0);
 
     if (clone.has_large_weight(c_n,c_d)) {
         clone.compress_haplotypes_local(c_n,c_d,0);

--- a/src/path_optimizer_mathopt.cpp
+++ b/src/path_optimizer_mathopt.cpp
@@ -1446,14 +1446,14 @@ TerminationReason optimize_reads_with_d_plus_n(
     write_time_log(output_dir, "optimize_d_plus_n_parse", t, true);
 
 
-    cerr << "-----------------" << '\n' <<
-            output_dir << '\n' <<
-            "Objective=" << to_string(result_n_d.objective_value()) << '\n' <<
-            "d_min=" << to_string(d_min) << '\n' <<
-            "n_max=" << to_string(n_max) << '\n' <<
-            "n=" << to_string(n) << '\n' <<
-            "d=" << to_string(d) << '\n' <<
-            "-----------------" << '\n';
+    // cerr << "-----------------" << ' ' <<
+    //         output_dir << ' ' <<
+    //         "Objective=" << to_string(result_n_d.objective_value()) << ' ' <<
+    //         "d_min=" << to_string(d_min) << ' ' <<
+    //         "n_max=" << to_string(n_max) << ' ' <<
+    //         "n=" << to_string(n) << ' ' <<
+    //         "d=" << to_string(d) << ' ' <<
+    //         "-----------------" << '\n';
 
     return termination_reason;
 }

--- a/src/test/test_cpptrace.cpp
+++ b/src/test/test_cpptrace.cpp
@@ -9,11 +9,12 @@ using std::cerr;
 void foo() {
     throw std::runtime_error("foo failed");
 }
+
 int main() {
     CPPTRACE_TRY {
         foo();
     } CPPTRACE_CATCH(const std::exception& e) {
         std::cerr<<"Exception: "<<e.what()<<std::endl;
-        cpptrace::from_current_exception().print();
+        cpptrace::from_current_exception().print_with_snippets();
     }
 }

--- a/src/test/test_cpptrace.cpp
+++ b/src/test/test_cpptrace.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <stdexcept>
+
+using std::runtime_error;
+using std::cerr;
+
+#include "cpptrace/from_current.hpp"
+
+void foo() {
+    throw std::runtime_error("foo failed");
+}
+int main() {
+    CPPTRACE_TRY {
+        foo();
+    } CPPTRACE_CATCH(const std::exception& e) {
+        std::cerr<<"Exception: "<<e.what()<<std::endl;
+        cpptrace::from_current_exception().print();
+    }
+}

--- a/wdl/hapestry_merge.wdl
+++ b/wdl/hapestry_merge.wdl
@@ -37,7 +37,6 @@ task merge {
         Boolean bam_not_hardclipped = false
         Boolean skip_solve = false
         Boolean samplewise = false
-        Boolean quadratic_objective = false
         Boolean rescale_weights = false
         Boolean prune_with_d_min = false
         Boolean skip_nonessential_logs = false
@@ -105,7 +104,6 @@ task merge {
         ~{if bam_not_hardclipped then "--bam_not_hardclipped" else ""} \
         ~{if skip_solve then "--skip_solve" else ""} \
         ~{if samplewise then "--samplewise" else ""} \
-        ~{if quadratic_objective then "--quadratic_objective" else ""} \
         ~{if rescale_weights then "--rescale_weights" else ""} \
         ~{if prune_with_d_min then "--prune_with_d_min" else ""} \
         ~{if skip_nonessential_logs then "--skip_nonessential_logs" else ""} \
@@ -163,7 +161,6 @@ task merge {
         reference_fa: "Reference fasta file"
         skip_solve: "Skip the solve step, only generate input CSV for the solve step"
         samplewise: "Solve each sample independently"
-        quadratic_objective: "Use quadratic objective which finds the normalized square distance from the utopia point"
         rescale_weights: "Use quadratic difference-from-best scaling for weights"
         prune_with_d_min: "Use initial solution of d_min to prune haps before starting final joint solution"
         skip_nonessential_logs: "Invoke this to skip logs: reads_to_paths.csv, solution.csv, nodes.csv"
@@ -213,7 +210,6 @@ workflow hapestry_merge {
         Boolean bam_not_hardclipped = false
         Boolean skip_solve = false
         Boolean samplewise = false
-        Boolean quadratic_objective = false
         Boolean rescale_weights = false
         Boolean prune_with_d_min = false
         Boolean skip_nonessential_logs = false
@@ -240,7 +236,6 @@ workflow hapestry_merge {
         reference_fa: "Reference fasta file"
         skip_solve: "Skip the solve step, only generate input CSV for the solve step"
         samplewise: "Solve each sample independently"
-        quadratic_objective: "Use quadratic objective which finds the normalized square distance from the utopia point"
         rescale_weights: "Use quadratic difference-from-best scaling for weights"
         prune_with_d_min: "Use initial solution of d_min to prune unused haplotypes before starting final joint model"
         skip_nonessential_logs: "Invoke this to skip logs: reads_to_paths.csv, solution.csv, nodes.csv"
@@ -269,7 +264,6 @@ workflow hapestry_merge {
             force_unique_reads = force_unique_reads,
             skip_solve = skip_solve,
             samplewise = samplewise,
-            quadratic_objective = quadratic_objective,
             rescale_weights = rescale_weights,
             prune_with_d_min = prune_with_d_min,
             skip_nonessential_logs = skip_nonessential_logs,

--- a/wdl/hapestry_merge.wdl
+++ b/wdl/hapestry_merge.wdl
@@ -41,6 +41,7 @@ task merge {
         Boolean rescale_weights = false
         Boolean prune_with_d_min = false
         Boolean skip_nonessential_logs = false
+        Boolean obscure_sample_names_from_csv = false
         Boolean upload_debug_data = false
 
         String docker = "fcunial/hapestry:merge"
@@ -109,6 +110,7 @@ task merge {
         ~{if rescale_weights then "--rescale_weights" else ""} \
         ~{if prune_with_d_min then "--prune_with_d_min" else ""} \
         ~{if skip_nonessential_logs then "--skip_nonessential_logs" else ""} \
+        ~{if obscure_sample_names_from_csv then "--obscure_sample_names_from_csv" else ""} \
         ~{if defined(gurobi_license) then "--use_gurobi" else ""}
 
         # Ensure write buffers are flushed to disk
@@ -167,6 +169,7 @@ task merge {
         compress: "Use reversible compression of the transmap to simplify before passing to solver"
         prune_with_d_min: "Use initial solution of d_min to prune haps before starting final joint solution"
         skip_nonessential_logs: "Invoke this to skip logs: reads_to_paths.csv, solution.csv, nodes.csv"
+        obscure_sample_names_from_csv: "Don't write sample names to reads_to_paths.csv. Instead, write an arbitrarily determined integer ID."
         tandems_bed: "BED file of tandem repeats"
         windows_bed: "BED file of windows to use for hapestry. Overrides automatic window finding if provided. Flank length is added to the bounds of each window in the BED."
     }
@@ -216,6 +219,7 @@ workflow hapestry_merge {
         Boolean rescale_weights = false
         Boolean prune_with_d_min = false
         Boolean skip_nonessential_logs = false
+        Boolean obscure_sample_names_from_csv = false
 
         String docker
         File? monitoring_script
@@ -242,6 +246,7 @@ workflow hapestry_merge {
         rescale_weights: "Use quadratic difference-from-best scaling for weights"
         prune_with_d_min: "Use initial solution of d_min to prune unused haplotypes before starting final joint model"
         skip_nonessential_logs: "Invoke this to skip logs: reads_to_paths.csv, solution.csv, nodes.csv"
+        obscure_sample_names_from_csv: "Don't write sample names to reads_to_paths.csv. Instead, write an arbitrarily determined integer ID."
         tandems_bed: "BED file of tandem repeats"
         windows_bed: "BED file of windows to use for hapestry. Overrides automatic window finding if provided. Flank length is added to the bounds of each window in the BED."
     }
@@ -270,6 +275,7 @@ workflow hapestry_merge {
             rescale_weights = rescale_weights,
             prune_with_d_min = prune_with_d_min,
             skip_nonessential_logs = skip_nonessential_logs,
+            obscure_sample_names_from_csv = obscure_sample_names_from_csv,
             docker = docker,
             monitoring_script = monitoring_script,
             runtime_attributes = merge_runtime_attributes

--- a/wdl/hapestry_merge.wdl
+++ b/wdl/hapestry_merge.wdl
@@ -37,6 +37,7 @@ task merge {
         Boolean bam_not_hardclipped = false
         Boolean skip_solve = false
         Boolean samplewise = false
+        Boolean compress = false
         Boolean rescale_weights = false
         Boolean prune_with_d_min = false
         Boolean skip_nonessential_logs = false
@@ -104,6 +105,7 @@ task merge {
         ~{if bam_not_hardclipped then "--bam_not_hardclipped" else ""} \
         ~{if skip_solve then "--skip_solve" else ""} \
         ~{if samplewise then "--samplewise" else ""} \
+        ~{if compress then "--compress" else ""} \
         ~{if rescale_weights then "--rescale_weights" else ""} \
         ~{if prune_with_d_min then "--prune_with_d_min" else ""} \
         ~{if skip_nonessential_logs then "--skip_nonessential_logs" else ""} \
@@ -162,6 +164,7 @@ task merge {
         skip_solve: "Skip the solve step, only generate input CSV for the solve step"
         samplewise: "Solve each sample independently"
         rescale_weights: "Use quadratic difference-from-best scaling for weights"
+        compress: "Use reversible compression of the transmap to simplify before passing to solver"
         prune_with_d_min: "Use initial solution of d_min to prune haps before starting final joint solution"
         skip_nonessential_logs: "Invoke this to skip logs: reads_to_paths.csv, solution.csv, nodes.csv"
         tandems_bed: "BED file of tandem repeats"

--- a/wdl/hapestry_merge_scattered.wdl
+++ b/wdl/hapestry_merge_scattered.wdl
@@ -326,7 +326,6 @@ workflow hapestry_merge_scattered {
         Boolean bam_not_hardclipped = false
         Boolean skip_solve = false
         Boolean samplewise = false
-        Boolean quadratic_objective = false
         Boolean rescale_weights = false
         Boolean prune_with_d_min = false
         Boolean skip_nonessential_logs = false
@@ -355,7 +354,6 @@ workflow hapestry_merge_scattered {
         reference_fa: "Reference fasta file"
         skip_solve: "Skip the solve step, only generate input CSV for the solve step"
         samplewise: "Solve each sample independently"
-        quadratic_objective: "Use quadratic objective which finds the normalized square distance from the utopia point"
         rescale_weights: "Use quadratic difference-from-best scaling for weights"
         prune_with_d_min: "Use initial solution of d_min to prune haps before starting final joint solution"
         skip_nonessential_logs: "Invoke this to skip logs: reads_to_paths.csv, solution.csv, nodes.csv"
@@ -405,7 +403,6 @@ workflow hapestry_merge_scattered {
                 force_unique_reads = force_unique_reads,
                 skip_solve = skip_solve,
                 samplewise = samplewise,
-                quadratic_objective = quadratic_objective,
                 rescale_weights = rescale_weights,
                 prune_with_d_min = prune_with_d_min,
                 skip_nonessential_logs = skip_nonessential_logs,


### PR DESCRIPTION
This brings in major additions to TransitiveMap which simplify the model for the solver, brought in with `git checkout` from `fc_compression` branch, written by @fabio-cunial 

In the process of integrating, I also added cpptrace, which allows run-time stack traces with only the minimal overhead of adding `-g` 

I also updated the Docker build process to be 2-tiered, in the sense that there is a base layer that builds an arbitrary recent commit, and then it rebuilds latest changes on top of that to minimize compile time for large dependencies like ORTools and htslib.